### PR TITLE
Add more aggressive name guessing for malformed but maybe recoverable non-standard data arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *dist/
 __pycache__
 *.egg-info
+*.pyc


### PR DESCRIPTION
This fixes #5.

This may be a breaking change for cases where `non-standard data array` *is* specified, but a userParam naming the array is present but does not end with `"array"`. Previously, the name of the array would be `"non-standard data array"`, but now it would be whatever the longest userParam is.