### PR TITLE
Fix warning when overriding use_index

### DIFF
--- a/pyteomics/auxiliary/file_helpers.py
+++ b/pyteomics/auxiliary/file_helpers.py
@@ -886,21 +886,18 @@ def _check_use_index(source, use_index, default):
             use_index = bool(use_index)
         if isinstance(source, basestring):
             return use_index if use_index is not None else default
-        seekable = True
         if hasattr(source, 'seekable'):
             if not source.seekable():
+                if use_index:
+                    warnings.warn('Cannot use indexing as {} is not seekable. '
+                        'Setting `use_index` to False.'.format(source))
                 use_index = False
-                seekable = False
         if hasattr(source, 'mode'):
             ui = 'b' in source.mode
             if use_index is not None and ui != use_index:
                 warnings.warn('use_index is {}, but the file mode is {}. '
                     'Setting use_index to {}'.format(use_index, source.mode, ui))
             use_index = ui
-
-        if use_index and not seekable:
-            warnings.warn('Cannot use indexing as {} is not seekable. Setting `use_index` to False.'.format(source))
-            use_index = False
 
         if use_index is not None:
             return use_index


### PR DESCRIPTION
The warning currently doesn't work as `use_index` is overridden immediately when file is determined to be seeakable. This moves the warning before `use_index` is set.