### PR TITLE
Parsing mztab 2.0 sections in `MzTab`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,6 +9,7 @@ Joshua Klein [mobiusklein]
 Vladimir Gorshkov [caetera]
 Andrey Rozenberg [alephreish]
 Julian Müller [jmueller95]
+[annalefarova]
 
 
 On Bitbucket (before March 1, 2020)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-4.4.1 beta 1
+4.4.1 beta 2
 ------------
 
  - Further tweaked behavior of :py:func:`pyteomics.auxiliary.file_helpers._check_use_index`, which is responsible for
@@ -9,6 +9,8 @@
 
  - Fix indexing when element identifiers contain XML-escaped characters
    (`#20 <https://github.com/levitsky/pyteomics/pull/20>`_ by Joshua Klein).
+
+ - Add support for MzTab 2.0 (`#22 <https://github.com/levitsky/pyteomics/pull/22>`_ by @annalefarova).
 
 4.4
 ---

--- a/pyteomics/mztab.py
+++ b/pyteomics/mztab.py
@@ -276,6 +276,10 @@ class MzTab(_MzTabParserBase):
             return self.protein_table
         if key in ('sml', ):
             return self.small_molecule_table
+        if key in ('smf', ):
+            return self.small_molecule_feature_table
+        if key in ('sme', ):
+            return self.small_molecule_evidence_table
         else:
             raise KeyError(key)
 
@@ -284,12 +288,16 @@ class MzTab(_MzTabParserBase):
         yield 'PEP', self.peptide_table
         yield 'PSM', self.spectrum_match_table
         yield 'SML', self.small_molecule_table
+        yield 'SMF', self.small_molecule_feature_table
+        yield 'SME', self.small_molecule_evidence_table
 
     def _init_tables(self):
         self.protein_table = _MzTabTable("protein")
         self.peptide_table = _MzTabTable("peptide")
         self.spectrum_match_table = _MzTabTable('psm')
         self.small_molecule_table = _MzTabTable('small molecule')
+        self.small_molecule_feature_table = _MzTabTable('small molecule feature')
+        self.small_molecule_evidence_table = _MzTabTable('small molecule evidence')
 
     def _transform_tables(self):
         if self._table_format == DATA_FRAME_FORMAT:
@@ -297,16 +305,22 @@ class MzTab(_MzTabParserBase):
             self.peptide_table = self.peptide_table.as_df()
             self.spectrum_match_table = self.spectrum_match_table.as_df('PSM_ID')
             self.small_molecule_table = self.small_molecule_table.as_df()
+            self.small_molecule_feature_table = self.small_molecule_feature_table.as_df()
+            self.small_molecule_evidence_table = self.small_molecule_evidence_table.as_df()
         elif self._table_format in (DICT_FORMAT, dict):
             self.protein_table = self.protein_table.as_dict()
             self.peptide_table = self.peptide_table.as_dict()
             self.spectrum_match_table = self.spectrum_match_table.as_dict()
             self.small_molecule_table = self.small_molecule_table.as_dict()
+            self.small_molecule_feature_table = self.small_molecule_feature_table.as_dict()
+            self.small_molecule_evidence_table = self.small_molecule_evidence_table.as_dict()
         elif callable(self._table_format):
             self.protein_table = self._table_format(self.protein_table)
             self.peptide_table = self._table_format(self.peptide_table)
             self.spectrum_match_table = self._table_format(self.spectrum_match_table)
             self.small_molecule_table = self._table_format(self.small_molecule_table)
+            self.small_molecule_feature_table = self._table_format(self.small_molecule_feature_table)
+            self.small_molecule_evidence_table = self._table_format(self.small_molecule_evidence_table)
 
     def _parse(self):
         for i, line in enumerate(self.file):
@@ -329,6 +343,10 @@ class MzTab(_MzTabParserBase):
                 self.spectrum_match_table.header = tokens[1:]
             elif tokens[0] == "SMH":
                 self.small_molecule_table.header = tokens[1:]
+            elif tokens[0] == "SFH":
+                self.small_molecule_feature_table.header = tokens[1:]
+            elif tokens[0] == "SEH":
+                self.small_molecule_evidence_table.header = tokens[1:]
             # rows
             elif tokens[0] == "PRT":
                 self.protein_table.add(tokens[1:])
@@ -338,6 +356,10 @@ class MzTab(_MzTabParserBase):
                 self.spectrum_match_table.add(tokens[1:])
             elif tokens[0] == "SML":
                 self.small_molecule_table.add(tokens[1:])
+            elif tokens[0] == "SMF":
+                self.small_molecule_feature_table.add(tokens[1:])
+            elif tokens[0] == "SME":
+                self.small_molecule_evidence_table.add(tokens[1:])
 
     def keys(self):
         return OrderedDict(self).keys()

--- a/pyteomics/mztab.py
+++ b/pyteomics/mztab.py
@@ -191,7 +191,6 @@ class MzTab(_MzTabParserBase):
         self._parse()
         self._determine_schema_version()
         self._transform_tables()
-        
 
     @property
     def table_format(self):
@@ -200,15 +199,26 @@ class MzTab(_MzTabParserBase):
     @property
     def version(self):
         return self.metadata['mzTab-version']
-        
 
     @property
     def mode(self):
-        return self.metadata.get('mzTab-mode', "")
+        return self.metadata.get('mzTab-mode')
 
     @property
     def type(self):
-        return self.metadata.get('mzTab-type', "")
+        return self.metadata.get('mzTab-type')
+
+    @property
+    def id(self):
+        return self.metadata.get('mzTab-ID')
+
+    @property
+    def title(self):
+        return self.metadata.get('title')
+
+    @property
+    def description(self):
+        return self.metadata.get('description')
 
     def collapse_properties(self, proplist):
         '''Collapse a flat property list into a hierchical structure.
@@ -287,12 +297,12 @@ class MzTab(_MzTabParserBase):
             raise KeyError(key)
 
     def __iter__(self):
-        if self.variant == "P": 
+        if self.variant == "P":
             yield 'PRT', self.protein_table
             yield 'PEP', self.peptide_table
             yield 'PSM', self.spectrum_match_table
             yield 'SML', self.small_molecule_table
-        elif self.variant == "M": 
+        elif self.variant == "M":
             yield 'SML', self.small_molecule_table
             yield 'SMF', self.small_molecule_feature_table
             yield 'SME', self.small_molecule_evidence_table

--- a/pyteomics/mztab.py
+++ b/pyteomics/mztab.py
@@ -5,13 +5,13 @@ mztab - mzTab file reader
 Summary
 -------
 
-`mzTab <http://www.psidev.info/mztab>`_  is one of the standards
+`mzTab <https://github.com/HUPO-PSI/mzTab>`_  is one of the standards
 developed by the Proteomics Informatics working group of the HUPO Proteomics
 Standard Initiative.
 
 This module provides a way to read mzTab files into a collection of
 :py:class:`pandas.DataFrame` instances in memory, along with a mapping
-of the file-level metadata.
+of the file-level metadata. MzTab specifications 1.0 and 2.0 are supported.
 
 Data access
 -----------

--- a/pyteomics/mztab.py
+++ b/pyteomics/mztab.py
@@ -189,7 +189,7 @@ class MzTab(_MzTabParserBase):
         self._table_format = table_format
         self._init_tables()
         self._parse()
-        self._determine_schema_version
+        self._determine_schema_version()
         self._transform_tables()
         
 

--- a/pyteomics/mztab.py
+++ b/pyteomics/mztab.py
@@ -200,14 +200,15 @@ class MzTab(_MzTabParserBase):
     @property
     def version(self):
         return self.metadata['mzTab-version']
+        
 
     @property
     def mode(self):
-        return self.metadata['mzTab-mode']
+        return self.metadata.get('mzTab-mode', "")
 
     @property
     def type(self):
-        return self.metadata['mzTab-type']
+        return self.metadata.get('mzTab-type', "")
 
     def collapse_properties(self, proplist):
         '''Collapse a flat property list into a hierchical structure.

--- a/tests/test_mztab.py
+++ b/tests/test_mztab.py
@@ -18,7 +18,7 @@ class MzTabTest(unittest.TestCase):
     def test_iter(self):
         reader = mztab.MzTab(self.path)
         tables = list(reader)
-        self.assertEqual(len(tables), 6)
+        self.assertEqual(len(tables), 4)
         [self.assertEqual(len(t), 2) for t in tables]
 
     def test_getitem(self):

--- a/tests/test_mztab.py
+++ b/tests/test_mztab.py
@@ -10,37 +10,40 @@ class MzTabTest(unittest.TestCase):
     path_mztab1 = 'test.mztab'
     path_mztab2 = 'test_mztab2.mztab'
 
-    def test_metadata(self):
+    def test_metadata_mztab1(self):
         reader_mztab1 = mztab.MzTab(self.path_mztab1)
         self.assertEqual(len(reader_mztab1.metadata), 208)
         value_from_mztab1 = reader_mztab1.metadata['fixed_mod[1]']
         self.assertEqual(value_from_mztab1, 'CHEMMOD:57.0214637236')
 
+    def test_metadata_mztab2(self):
         reader_mztab2 = mztab.MzTab(self.path_mztab2)
         self.assertEqual(len(reader_mztab2.metadata), 61)
         value_from_mztab2 = reader_mztab2.metadata['sample_processing[1]']
         self.assertEqual(value_from_mztab2, 'high performance liquid chromatography')
 
-
-    def test_iter(self):
+    def test_iter_mztab1(self):
         reader_mztab1 = mztab.MzTab(self.path_mztab1)
         tables = list(reader_mztab1)
         self.assertEqual(len(tables), 4)
         [self.assertEqual(len(t), 2) for t in tables]
 
+    def test_iter_mztab2(self):
         reader_mztab2 = mztab.MzTab(self.path_mztab2)
         tables = list(reader_mztab2)
         self.assertEqual(len(tables), 3)
         [self.assertEqual(len(t), 2) for t in tables]
 
-    def test_getitem(self):
+    def test_getitem_mztab1(self):
         reader_mztab1 = mztab.MzTab(self.path_mztab1)
         table = reader_mztab1['psm']
         self.assertIsInstance(table, mztab.pd.DataFrame)
 
+    def test_getitem_mztab2(self):
         reader_mztab2 = mztab.MzTab(self.path_mztab2)
         table = reader_mztab2['sme']
         self.assertIsInstance(table, mztab.pd.DataFrame)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_mztab.py
+++ b/tests/test_mztab.py
@@ -7,23 +7,39 @@ from pyteomics import mztab
 
 class MzTabTest(unittest.TestCase):
 
-    path = 'test.mztab'
+    path_mztab1 = 'test.mztab'
+    path_mztab2 = 'test_mztab2'
 
     def test_metadata(self):
-        reader = mztab.MzTab(self.path)
-        self.assertEqual(len(reader.metadata), 208)
-        value = reader.metadata['fixed_mod[1]']
-        self.assertEqual(value, 'CHEMMOD:57.0214637236')
+        reader_mztab1 = mztab.MzTab(self.path_mztab1)
+        self.assertEqual(len(reader_mztab1.metadata), 208)
+        value_from_mztab1 = reader_mztab1.metadata['fixed_mod[1]']
+        self.assertEqual(value_from_mztab1, 'CHEMMOD:57.0214637236')
+
+        reader_mztab2 = mztab.MzTab(self.path_mztab2)
+        self.assertEqual(len(reader_mztab2.metadata), 61)
+        value_from_mztab2 = reader_mztab2.metadata['sample_processing[1]']
+        self.assertEqual(value_from_mztab2, 'MSIO, MSIO:0000148, high performance liquid chromatography')
+
 
     def test_iter(self):
-        reader = mztab.MzTab(self.path)
-        tables = list(reader)
+        reader_mztab1 = mztab.MzTab(self.path_mztab1)
+        tables = list(reader_mztab1)
         self.assertEqual(len(tables), 4)
         [self.assertEqual(len(t), 2) for t in tables]
 
+        reader_mztab2 = mztab.MzTab(self.path_mztab2)
+        tables = list(reader_mztab2)
+        self.assertEqual(len(tables), 3)
+        [self.assertEqual(len(t), 2) for t in tables]
+
     def test_getitem(self):
-        reader = mztab.MzTab(self.path)
-        table = reader['psm']
+        reader_mztab1 = mztab.MzTab(self.path_mztab1)
+        table = reader_mztab1['psm']
+        self.assertIsInstance(table, mztab.pd.DataFrame)
+
+        reader_mztab2 = mztab.MzTab(self.path_mztab2)
+        table = reader_mztab2['sme']
         self.assertIsInstance(table, mztab.pd.DataFrame)
 
 if __name__ == '__main__':

--- a/tests/test_mztab.py
+++ b/tests/test_mztab.py
@@ -18,7 +18,7 @@ class MzTabTest(unittest.TestCase):
     def test_iter(self):
         reader = mztab.MzTab(self.path)
         tables = list(reader)
-        self.assertEqual(len(tables), 4)
+        self.assertEqual(len(tables), 6)
         [self.assertEqual(len(t), 2) for t in tables]
 
     def test_getitem(self):

--- a/tests/test_mztab.py
+++ b/tests/test_mztab.py
@@ -19,7 +19,7 @@ class MzTabTest(unittest.TestCase):
         reader_mztab2 = mztab.MzTab(self.path_mztab2)
         self.assertEqual(len(reader_mztab2.metadata), 61)
         value_from_mztab2 = reader_mztab2.metadata['sample_processing[1]']
-        self.assertEqual(value_from_mztab2, 'MSIO, MSIO:0000148, high performance liquid chromatography')
+        self.assertEqual(value_from_mztab2, 'high performance liquid chromatography')
 
 
     def test_iter(self):

--- a/tests/test_mztab.py
+++ b/tests/test_mztab.py
@@ -8,7 +8,7 @@ from pyteomics import mztab
 class MzTabTest(unittest.TestCase):
 
     path_mztab1 = 'test.mztab'
-    path_mztab2 = 'test_mztab2'
+    path_mztab2 = 'test_mztab2.mztab'
 
     def test_metadata(self):
         reader_mztab1 = mztab.MzTab(self.path_mztab1)

--- a/tests/test_mztab2.mztab
+++ b/tests/test_mztab2.mztab
@@ -1,0 +1,86 @@
+COM	Meta data section																				
+MTD	mzTab-version	2.0.0-M																			
+MTD	mzTab-ID	ISAS-2018-1234																			
+MTD	description	Minimal proposed sample file for identification and quantification of lipids																			
+MTD	publication[1]	pubmed:29039908 | doi:10.1021/acs.analchem.7b03576																			
+MTD	cv[1]-label	MS																			
+MTD	cv[1]-full_name	PSI-MS controlled vocabulary																			
+MTD	cv[1]-version	4.0.18																			
+MTD	cv[1]-uri	https://github.com/HUPO-PSI/psi-ms-CV/blob/master/psi-ms.obo																			
+MTD	cv[2]-label	MSIO
+MTD	cv[2]-uri	https://www.ebi.ac.uk/ols/ontologies/msio
+MTD	cv[2]-version	1.0.1
+MTD	cv[2]-full_name	Metabolomics Standards Initiative Ontology (MSIO)																			
+MTD	cv[3]-label	UO																			
+MTD	cv[3]-full_name	Units of Measurement Ontology																			
+MTD	cv[3]-version	 2017-09-25																			
+MTD	cv[3]-uri	http://purl.obolibrary.org/obo/uo.owl																			
+MTD	quantification_method	[MS, MS:1001838, SRM quantitation analysis, ]																			
+MTD	sample_processing[1]	[MSIO, MSIO:0000148, high performance liquid chromatography, ]
+MTD	instrument[1]-name	[MS, MS:1001911, Q Exactive , ]																			
+MTD	instrument[1]-source	[MS, MS:1000073, electrospray ionization, ]																			
+MTD	instrument[1]-analyzer[1]	[MS, MS:1000081, quadrupole, ]																			
+MTD	instrument[1]-analyzer[2]	[MS, MS:1000484, orbitrap, ]																			
+MTD	instrument[1]-detector	[MS, MS:1000624, inductive detector, ]																			
+MTD	software[1]	[MS, MS:1000532, Xcalibur,2.8-280502/2.8.1.2806]																			
+MTD	software[1]-setting[1]	ScheduledSRMWindow: 2 min																			
+MTD	software[1]-setting[2]	CycleTime: 2 s																			
+MTD	software[2]	[MS, MS:1000922, Skyline, 3.5.0.9319]																			
+MTD	software[2]-setting[1]	MSMSmassrange: (50.0, 1800.0)																			
+MTD	sample[1]	QEx-1273-prm-sp1																			
+MTD	sample[1]-description	Sphingolipids with concentration reported as picomolar per mg of protein, abundances are reported after calibration correction.																			
+MTD	ms_run[1]-location	file:///C:/data/QEx-1273-prm-sp1.mzML																			
+MTD	ms_run[1]-format	[MS, MS:1000584, mzML file, ]																			
+MTD	ms_run[1]-id_format	[MS, MS:1000768, Thermo nativeID format, ]																			
+MTD	ms_run[1]-scan_polarity[1]	[MS, MS:1000130, positive scan, ]																			
+MTD	ms_run[1]-instrument_ref	instrument[1]																			
+MTD	assay[1]	Description of assay 1																			
+MTD	assay[1]-sample_ref	sample[1]																			
+MTD	assay[1]-ms_run_ref	ms_run[1]																			
+MTD	study_variable[1]	Sphingolipid SRM Quantitation																			
+MTD	study_variable[1]-assay_refs	assay[1]																			
+MTD	study_variable[1]-description	sphingolipid srm quantitation																			
+MTD	study_variable[1]-average_function	[MS, MS:1002883, median, ]																			
+MTD	study_variable[1]-variation_function	[MS, MS:1002885, standard error, ]																			
+MTD	small_molecule-quantification_unit	[UO, UO:0000072, picomolal, ]																			
+MTD	small_molecule_feature-quantification_unit	[UO, UO:0000072, picomolal, ]																			
+MTD	small_molecule-identification_reliability	[MS, MS:1002896, compound identification confidence level, ]																			
+MTD	database[1]	[,, Pubchem, ]																			
+MTD	database[1]-prefix	PUBCHEM-CPD																			
+MTD	database[1]-version	02.12.2017																			
+MTD	database[1]-uri	https://www.ncbi.nlm.nih.gov/pccompound																			
+MTD	database[2]	[,, LipidMaps, ]																			
+MTD	database[2]-prefix	LM																			
+MTD	database[2]-version	2017-12																			
+MTD	database[2]-uri	http://www.lipidmaps.org/																			
+MTD	database[3]	[,, LipidCreator Transitions, ]																			
+MTD	database[3]-prefix	LCTR																			
+MTD	database[3]-version	2018-07																			
+MTD	database[3]-uri	https://lifs.isas.de/lipidcreator																			
+COM	MTD	colunit-small_molecule	retention_time=[UO, UO:0000010, second, ]																		
+MTD	colunit-small_molecule_evidence	opt_global_mass_error=[UO, UO:0000169, parts per million, ]																			
+MTD	id_confidence_measure[1]	[MS, MS:1002890, fragmentation score, ]																			
+MTD	external_study_uri[1]	file:///C:/data/prm.sky.zip																			
+																					
+COM	"MzTab 2.0.0-M ""proposed"" specification"																				
+COM	Summary rows. 																				
+COM	Evidences (e.g. multiple modifications, adducts incl. charge variants are summarized). 																				
+COM	For most use cases this summary lines may be sufficient.																				
+COM	Negative and positive scan polarities are currently not explicitly included, this is still under debate in the mzTAB community.																				
+SMH	SML_ID	SMF_ID_REFS	chemical_name	database_identifier	chemical_formula	smiles	inchi	uri	theoretical_neutral_mass	adduct_ions	reliability	best_id_confidence_measure	best_id_confidence_value	abundance_assay[1]	abundance_study_variable[1]	abundance_variation_study_variable[1]	opt_global_lipid_category	opt_global_lipid_species	opt_global_lipid_best_id_level
+SML	1	1 | 2 | 3 | 4	Cer(d18:1/24:0)	LM:LMSP02010012	C42H83NO3	CCCCCCCCCCCCCCCCCCCCCCCC(=O)N[C@@H](CO)[C@H](O)/C=C/CCCCCCCCCCCCC	InChI=1S/C42H83NO3/c1-3-5-7-9-11-13-15-17-18-19-20-21-22-23-24-26-28-30-32-34-36-38-42(46)43-40(39-44)41(45)37-35-33-31-29-27-25-16-14-12-10-8-6-4-2/h35,37,40-41,44-45H,3-34,36,38-39H2,1-2H3,(H,43,46)/b37-35+/t40-,41+/m0/s1	http://www.lipidmaps.org/data/LMSDRecord.php?LM_ID=LMSP02010012	649.6373	[M+H]+	2	[,, qualifier ions exact mass,]	0.958	4.448784E-05	4.448784E-05	0	Sphingolipids	Cer 42:1	Cer d18:1/24:0
+																					
+COM	MS feature rows , used to report m/z and individual abundance information for quantification																				
+SFH	SMF_ID	SME_ID_REFS	SME_ID_REF_ambiguity_code	adduct_ion	isotopomer	exp_mass_to_charge	charge	retention_time_in_seconds	retention_time_in_seconds_start	retention_time_in_seconds_end	abundance_assay[1]	opt_global_quantifiers_SMF_ID_REFS									
+SMF	1	1	null	[M+H]1+	null	650.6432	1	821.2341	756.0000	954.0000	4.448784E-05	3									
+SMF	2	2	null	null	null	252.2677	1	821.2341	756.0000	954.0000	6.673176E-06	null									
+SMF	3	3	null	null	null	264.2689	1	821.2341	756.0000	954.0000	1.3346352E-05	null									
+SMF	4	4	null	null	null	282.2788	1	821.2341	756.0000	954.0000	9.831813E-06	null									
+																					
+COM	Evidence rows for parent / fragment ions.																				
+COM	Primary use case: report single hits from spectral library or accurate mass searches without quantification. -> Qualification																				
+SEH	SME_ID	evidence_input_id	database_identifier	chemical_formula	smiles	inchi	chemical_name	uri	derivatized_form	adduct_ion	exp_mass_to_charge	charge	theoretical_mass_to_charge	opt_global_mass_error	spectra_ref	identification_method	ms_level	id_confidence_measure[1]	rank	opt_global_qualifiers_evidence_grouping_ID_REFS
+SME	1	1	LM:LMSP0501AB02	C42H83NO3	CCCCCCCCCCCCCCCCCCCCCCCC(=O)N[C@@H](CO)[C@H](O)/C=C/CCCCCCCCCCCCC	InChI=1S/C42H83NO3/c1-3-5-7-9-11-13-15-17-18-19-20-21-22-23-24-26-28-30-32-34-36-38-42(46)43-40(39-44)41(45)37-35-33-31-29-27-25-16-14-12-10-8-6-4-2/h35,37,40-41,44-45H,3-34,36,38-39H2,1-2H3,(H,43,46)/b37-35+/t40-,41+/m0/s1	LacCer d18:1/12:0	http://www.lipidmaps.org/data/LMSDRecord.php?LM_ID=LMSP02010012	null	[M+H]1+	650.6432	1	650.6446	-2.1517	ms_run[1]:controllerType=0 controllerNumber=1 scan=731	[,, qualifier ions exact mass,]	[MS,MS:1000511, ms level, 1]	0.958	1	2
+SME	2	2	LCTR:LCTR0809812	C17H33N	null	null	Cer d18:1/24:0 W' - CHO	null	null	null	252.2677	1	252.2686	-3.5676	ms_run[1]:controllerType=0 controllerNumber=1 scan=732	[,, exact mass, ]	[MS,MS:1000511, ms level, 2]	0.9780	1	null
+SME	3	2	LCTR:LCTR0871245	C18H33N	null	null	Cer d18:1/24:0 W''	null	null	null	264.2689	1	264.2686	-1.1352	ms_run[1]:controllerType=0 controllerNumber=1 scan=732	[,, exact mass, ]	[MS,MS:1000511, ms level, 2]	0.7500	1	null
+SME	4	2	LCTR:LCTR0809711	C18H35NO	null	null	Cer d18:1/24:0 W'	null	null	null	282.2788	1	282.2791	-1.0628	ms_run[1]:controllerType=0 controllerNumber=1 scan=732	[,, exact mass, ]	[MS,MS:1000511, ms level, 2]	0.8760	1	null


### PR DESCRIPTION
Class MzTab was extended to parse sections from mztab 2.0.  The following sections were added: "small molecule feature table" and "small molecule evidence table".