### PR TITLE
Fixed version parsing

### DIFF
--- a/pyteomics/mztab.py
+++ b/pyteomics/mztab.py
@@ -744,7 +744,7 @@ class MzTab(_MzTabParserBase):
                 self.small_molecule_evidence_table.add(tokens[1:])
 
     def _determine_schema_version(self):
-        version_parsed, variant = re.search(r"(?P<schema_version>\d+(?:.\d+(?:.\d+)?)?)(?:-(?P<schema_variant>[MP]))?", str(self.version)).groups()
+        version_parsed, variant = re.search(r"(?P<schema_version>\d+(?:\.\d+(?:\.\d+)?)?)(?:-(?P<schema_variant>[MP]))?", str(self.version)).groups()
         if variant is None:
             variant = "P"
         self.num_version = [int(v) for v in version_parsed.split(".")]

--- a/pyteomics/mztab.py
+++ b/pyteomics/mztab.py
@@ -744,10 +744,13 @@ class MzTab(_MzTabParserBase):
                 self.small_molecule_evidence_table.add(tokens[1:])
 
     def _determine_schema_version(self):
-        version_parsed, _, variant = str(self.version).partition("-")
-        if variant is None or (variant != "M" and variant != "P"):
+        version_parsed, variant = re.search(r"(?P<schema_version>\d+(?:.\d+(?:.\d+)?)?)(?:-(?P<schema_variant>[MP]))?", str(self.version)).groups()
+        if variant is None:
             variant = "P"
         self.num_version = [int(v) for v in version_parsed.split(".")]
+        # Ensure self.num_version is 3-tuple
+        while len(self.num_version) < 3:
+            self.num_version.append(0)
         self.variant = variant
 
     def keys(self):

--- a/pyteomics/mztab.py
+++ b/pyteomics/mztab.py
@@ -744,8 +744,8 @@ class MzTab(_MzTabParserBase):
                 self.small_molecule_evidence_table.add(tokens[1:])
 
     def _determine_schema_version(self):
-        version_parsed, variant = re.search(r"(?P<schema_version>\d+.\d+.\d+)(?:-(?P<schema_variant>[MP]))?", self.version).groups()
-        if variant is None:
+        version_parsed, _, variant = str(self.version).partition("-")
+        if variant is None or (variant != "M" and variant != "P"):
             variant = "P"
         self.num_version = [int(v) for v in version_parsed.split(".")]
         self.variant = variant


### PR DESCRIPTION
Accepts version numbers that do not necessarily contain 3 numbers (x.x.x) - can read versions that contain 1 or 2 numbers (x) or (x.x)