### PR TITLE
Fix Unimod Compatibility With SQLAlchemy 1.4.X 

### DIFF
--- a/pyteomics/mass/unimod.py
+++ b/pyteomics/mass/unimod.py
@@ -44,15 +44,15 @@ from . import mass
 model_registry = set()
 
 
-class SubclassRegistringDeclarativeMeta(DeclarativeMeta):
+class SubclassRegisteringDeclarativeMeta(DeclarativeMeta):
     def __new__(cls, name, parents, attrs):
-        new_type = super(SubclassRegistringDeclarativeMeta,
+        new_type = super(SubclassRegisteringDeclarativeMeta,
                          cls).__new__(cls, name, parents, attrs)
         model_registry.add(new_type)
         return new_type
 
 
-Base = declarative_base(metaclass=SubclassRegistringDeclarativeMeta)
+Base = declarative_base(metaclass=SubclassRegisteringDeclarativeMeta)
 
 _unimod_xml_download_url = 'http://www.unimod.org/xml/unimod_tables.xml'
 


### PR DESCRIPTION
Addresses #31 

With the migration underway at SQLAlchemy from 1.3 to 1.4, internal details that I shouldn't have relied on are changing as they prepare for a major version change. This now explicitly gathers model types without relying on SQLAlchemy doing it for us indirectly. 