### PR TITLE
Index additional tags for mzIdentML

### DIFF
--- a/pyteomics/mzid.py
+++ b/pyteomics/mzid.py
@@ -108,9 +108,15 @@ class MzIdentML(xml.MultiProcessingXML, xml.IndexSavingXML):
     _default_version = '1.1.0'
     _default_iter_tag = 'SpectrumIdentificationResult'
     _structures_to_flatten = {'Fragmentation'}
-    _indexed_tags = {'SpectrumIdentificationResult',
-        'PeptideEvidence', 'SpectrumIdentificationItem', 'SearchDatabase',
-        'DBSequence', 'SpectraData', 'Peptide'}
+    _indexed_tags = {'SpectrumIdentificationResult', 'SpectrumIdentificationItem',
+                     'SearchDatabase', 'SourceFile', 'SpectraData', 'Sample',
+                     'DBSequence',  'Peptide', 'PeptideEvidence',
+                     'Measure', 'TranslationTable', 'MassTable', 'Enzyme',
+                     'Organization', 'AnalysisSoftware', 'BibliographicReference', 'Person', 'Provider',
+                     'SpectrumIdentificationList', 'SpectrumIdentificationProtocol', 'SpectrumIdentification',
+                     'ProteinDetectionList', 'ProteinDetectionProtocol', 'ProteinDetection',
+                     'ProteinDetectionHypothesis', 'ProteinAmbiguityGroup',
+                    }
 
     _element_handlers = xml.XML._element_handlers.copy()
     _element_handlers.update({

--- a/pyteomics/xml.py
+++ b/pyteomics/xml.py
@@ -1287,6 +1287,10 @@ class Iterfind(object):
 
 class IndexedIterfind(TaskMappingMixin, Iterfind):
 
+    def __init__(self, parser, tag_name, **kwargs):
+        TaskMappingMixin.__init__(self, **kwargs)
+        Iterfind.__init__(self, parser, tag_name, **kwargs)
+
     def _task_map_iterator(self):
         """Returns the :class:`Iteratable` to use when dealing work items onto the input IPC
         queue used by :meth:`map`

--- a/pyteomics/xml.py
+++ b/pyteomics/xml.py
@@ -1281,7 +1281,7 @@ class Iterfind(object):
     def __exit__(self, *args, **kwargs):
         self.reset()
 
-    def map(self *args,**kwargs):
+    def map(self, *args,**kwargs):
         raise NotImplementedError("This query isn't indexed, it cannot be mapped with multiprocessing")
 
 

--- a/pyteomics/xml.py
+++ b/pyteomics/xml.py
@@ -1251,8 +1251,11 @@ class Iterfind(TaskMappingMixin):
 
     @property
     def is_indexed(self):
-        if self.parser.index is not None:
-            return self.tag_name in self.parser.index
+        if hasattr(self.parser, 'index'):
+            if self.parser.index is not None:
+                index = self.parser.index
+                if isinstance(index, HierarchicalOffsetIndex):
+                    return bool(self.tag_name in index and index[self.tag_name])
         return False
 
     def _task_map_iterator(self):

--- a/pyteomics/xml.py
+++ b/pyteomics/xml.py
@@ -1295,9 +1295,6 @@ class Iterfind(object):
             return self._get_by_slice(i)
         return self._get_by_index(i)
 
-    def __len__(self):
-        raise NotImplementedError()
-
 
 class IndexedIterfind(TaskMappingMixin, Iterfind):
 

--- a/pyteomics/xml.py
+++ b/pyteomics/xml.py
@@ -1230,8 +1230,16 @@ class Iterfind(TaskMappingMixin):
     def __iter__(self):
         return self
 
+    def _yield_from_index(self):
+        for key in self._task_map_iterator():
+            yield self.parser.get_by_id(key, **self.config)
+
     def _make_iterator(self):
-        return self.parser._iterfind_impl(self.tag_name, **self.config)
+        if self.is_indexed:
+            return self._yield_from_index()
+        else:
+            return self.parser._iterfind_impl(self.tag_name, **self.config)
+
 
     def __next__(self):
         if self._iterator is None:
@@ -1240,6 +1248,12 @@ class Iterfind(TaskMappingMixin):
 
     def next(self):
         return self.__next__()
+
+    @property
+    def is_indexed(self):
+        if self.parser.index is not None:
+            return self.tag_name in self.parser.index
+        return False
 
     def _task_map_iterator(self):
         """Returns the :class:`Iteratable` to use when dealing work items onto the input IPC


### PR DESCRIPTION
Closes #33 

The root cause in #33 is that when processing a `FragmentationArray`, the `measure_ref` attribute must be resolved. This leads to a `get_by_id` call, but the requested ID is not in the index, so it leads to a sequential scan along the entire file. Each `SpectrumIdentificationItem` contains at least three `FragmentationArray`, each of which references all three `Measure` elements, leading to the seeming stand-still for a single `SpectrumIdentificationResult`

To avoid this cropping up in the future, I've added all reference-able element types to the offset index. We'll see if this leads to an undesirable slowdown in initialization speed as it makes the indexer generate a more complex tokenizer pattern.