### PR TITLE
Addition of spectrum_utils backend

### DIFF
--- a/pyteomics/auxiliary/utils.py
+++ b/pyteomics/auxiliary/utils.py
@@ -21,6 +21,7 @@ try:
 except ImportError:
     pynumpress = None
 
+
 def print_tree(d, indent_str=' -> ', indent_count=1):
     """Read a nested dict (with strings as keys) and print its structure.
     """
@@ -89,17 +90,20 @@ def _decode_base64_data_array(source, dtype, is_compressed):
 _default_compression_map = {
         'no compression': lambda x: x,
         'zlib compression': zlib.decompress,
-    }
+}
+
 
 def _pynumpressDecompress(decoder):
     def decode(data):
         return decoder(np.frombuffer(data, dtype=np.uint8))
     return decode
 
+
 def _zlibNumpress(decoder):
     def decode(data):
         return decoder(np.frombuffer(zlib.decompress(data), dtype=np.uint8))
     return decode
+
 
 if pynumpress:
     _default_compression_map.update(
@@ -111,6 +115,7 @@ if pynumpress:
             'MS-Numpress positive integer compression followed by zlib compression':   _zlibNumpress(pynumpress.decode_pic),
             'MS-Numpress linear prediction compression followed by zlib compression':  _zlibNumpress(pynumpress.decode_linear),
         })
+
 
 if np is not None:
     class BinaryDataArrayTransformer(object):

--- a/pyteomics/pylab_aux.py
+++ b/pyteomics/pylab_aux.py
@@ -333,13 +333,14 @@ def plot_qvalue_curve(qvalues, *args, **kwargs):
 
 
 def _default_plot_spectrum(spectrum, *args, **kwargs):
+    ax = kwargs.pop('ax', None) or pylab.gca()
     if kwargs.pop('centroided', True):
         kwargs.setdefault('align', 'center')
         kwargs.setdefault('width', 0)
         kwargs.setdefault('linewidth', 1)
         kwargs.setdefault('edgecolor', 'k')
-        return pylab.bar(spectrum['m/z array'], spectrum['intensity array'], *args, **kwargs)
-    return pylab.plot(spectrum['m/z array'], spectrum['intensity array'], *args, **kwargs)
+        return ax.bar(spectrum['m/z array'], spectrum['intensity array'], *args, **kwargs)
+    return ax.plot(spectrum['m/z array'], spectrum['intensity array'], *args, **kwargs)
 
 
 def _spectrum_utils_plot(spectrum, *args, **kwargs):
@@ -444,6 +445,7 @@ def _default_annotate_spectrum(spectrum, peptide, *args, **kwargs):
     if precursor_charge is None:
         raise PyteomicsError('Could not extract precursor charge from spectrum. Please specify `precursor_charge` kwarg.')
     maxcharge = kwargs.pop('maxcharge', max(1, precursor_charge - 1))
+    ax = kwargs.get('ax', None)
     # end of common kwargs
 
     # backend-specific kwargs
@@ -488,7 +490,7 @@ def _default_annotate_spectrum(spectrum, peptide, *args, **kwargs):
         else:
             match = np.where(matrix / spectrum['m/z array'] < rtol)
         pseudo_spec = {'m/z array': spectrum['m/z array'][match[1]], 'intensity array': spectrum['intensity array'][match[1]]}
-        plot_spectrum(pseudo_spec, centroided=True, edgecolor=c)
+        plot_spectrum(pseudo_spec, centroided=True, edgecolor=c, ax=ax)
         for j, i in zip(*match):
             x = spectrum['m/z array'][i]
             y = spectrum['intensity array'][i] + maxpeak * 0.02
@@ -628,14 +630,14 @@ def _spectrum_utils_annotate_plot(spectrum, peptide, *args, **kwargs):
 
     with SpectrumUtilsColorScheme(kwargs.pop('colors', None)):
         spectrum = _spectrum_utils_annotate_spectrum(spectrum, peptide, *args, **kwargs)
-        return sup.spectrum(spectrum, annot_kws=kwargs.pop('text_kw'))
+        return sup.spectrum(spectrum, annot_kws=kwargs.pop('text_kw', None), ax=kwargs.pop('ax', None))
 
 
 def _spectrum_utils_annotate_iplot(spectrum, peptide, *args, **kwargs):
     import spectrum_utils.iplot as supi
     with SpectrumUtilsColorScheme(kwargs.pop('colors', None)):
         spectrum = _spectrum_utils_annotate_spectrum(spectrum, peptide, *args, **kwargs)
-        return supi.spectrum(spectrum, annot_kws=kwargs.pop('text_kw'))
+        return supi.spectrum(spectrum, annot_kws=kwargs.pop('text_kw', None), ax=kwargs.pop('ax', None))
 
 
 _annotation_backends = {
@@ -680,6 +682,8 @@ def annotate_spectrum(spectrum, peptide, *args, **kwargs):
         Label for the Y axis. Default is "intensity".
     title : str, keyword only, optional
         The title. Empty by default.
+    ax : matplotlib.pyplot.Axes, keyword only, optional
+        Axes to draw the spectrum.
 
     *args
         Passed to the plotting backend.

--- a/pyteomics/pylab_aux.py
+++ b/pyteomics/pylab_aux.py
@@ -545,22 +545,6 @@ class SpectrumUtilsColorScheme:
         sup.colors = self.previous_colors
 
 
-class SpectrumUtilsStaticModifications:
-    """Context manager that temporarily changes `spectrum_utils` static modifications."""
-    def __init__(self, mods):
-        self.mods = mods
-        self.previous_aa_mass = sus._aa_mass
-
-    def __enter__(self):
-        if self.mods:
-            sus.reset_modifications()
-            for mod in self.mods:
-                sus.static_modification(*mod)
-
-    def __exit__(self, *args, **kwargs):
-        sup._aa_mass = self.previous_aa_mass
-
-
 def _spectrum_utils_parse_sequence(sequence, aa_mass=None):
     if isinstance(sequence, str):
         parsed = parser.parse(sequence, show_unmodified_termini=True, labels=aa_mass, allow_unknown_modifications=True)
@@ -623,7 +607,7 @@ def annotate_spectrum(spectrum, peptide, *args, **kwargs):
         The `spectrum_utils.iplot` backend requires installing :py:mod:`spectrum_utils[iplot]`.
     ion_types : Container, keyword only, optional
         Ion types to be considered for annotation. Default is `('b', 'y')`.
-    precursor_charge : str, keyword only, optional
+    precursor_charge : int, keyword only, optional
         If not specified, an attempt is made to extract it from `spectrum`.
     maxcharge : int, keyword only, optional
         Maximum charge state for fragment ions to be considered. Default is `precursor_charge - 1`.
@@ -633,15 +617,12 @@ def annotate_spectrum(spectrum, peptide, *args, **kwargs):
         A fixed m/z tolerance value for peak matching. Alternative to `rtol`.
     rtol : float, keyword only, optional
         A relative m/z error for peak matching. Default is 10 ppm.
-    text_kw : dict, keyword only, optional
-        Keyword arguments for :py:func:`pylab.text`.
     aa_mass : dict, keyword only, optional
         A dictionary of amino acid residue masses.
     *args
         Passed to the plotting backend.
     **kwargs
         Passed to the plotting backend.
-
 
     centroided : bool, keyword only, optional
         Passed to :py:func:`plot_spectrum`. Only works with `default` backend.
@@ -651,11 +632,12 @@ def annotate_spectrum(spectrum, peptide, *args, **kwargs):
     mass_data : dict, keyword only, optional
         A dictionary of element masses to override :py:const:`pyteomics.mass.nist_mass`.
         Only works with `default` backend.
+    text_kw : dict, keyword only, optional
+        Keyword arguments for :py:func:`pylab.text`. Only works with `default` backend.
     adjust_text : bool, keyword only, optional
         Adjust the overlapping text annotations using :py:mod:`adjustText`. Only works with `default` backend.
     adjust_kw : dict, keyword only, optional
         Keyword arguments for :py:func:`adjust_text`. Only works with `default` backend.
-
 
     remove_precursor_peak : bool, keyword only, optional
         Remove precursor peak from spectrum before annotation. Default is :p:const:`False`.
@@ -680,7 +662,13 @@ def annotate_spectrum(spectrum, peptide, *args, **kwargs):
     modifications : dict, optional
         A dict of variable modifications as described in
         `spectrum_utils documentation <https://spectrum-utils.readthedocs.io/en/latest/processing.html#variable-modifications>`_.
-        You don't need to provide this if your `peptide` is a modX sequence and you supply `aa_mass`.
+
+        .. note::
+            You don't need to provide this if your `peptide` is a modX sequence and you supply `aa_mass`.
+
+        .. note::
+            To apply static modifications, provide `aa_mass` with modified masses.
+
     """
     bname = kwargs.pop('backend', 'default')
     backend = _annotation_backends.get(bname)

--- a/pyteomics/pylab_aux.py
+++ b/pyteomics/pylab_aux.py
@@ -24,6 +24,8 @@ Spectrum visualization
 
   :py:func:`annotate_spectrum` - plot and annotate peaks in MS/MS spectrum.
 
+  :py:func:`mirror` - create a mirror plot of two spectra (using :py:mod:`spectrum_utils`).
+
 FDR control
 -----------
 
@@ -728,3 +730,30 @@ def annotate_spectrum(spectrum, peptide, *args, **kwargs):
         raise PyteomicsError('Unknown backend name: {}. Should be one of: {}.'.format(
             bname, '; '.join(_annotation_backends)))
     return backend(spectrum, peptide, *args, **kwargs)
+
+
+def mirror(spec_top, spec_bottom, peptide=None, spectrum_kws=None, ax=None, **kwargs):
+    """Create a mirror plot of two (possible annotated) spectra using `spectrum_utils`.
+
+    .. note ::
+        Requires :py:mod:`spectrum_utils`.
+
+    Parameters
+    ----------
+    spec_top : dict
+        A spectrum as returned by Pyteomics parsers. Needs to have 'm/z array' and 'intensity array' keys.
+    spec_bottom : dict
+        A spectrum as returned by Pyteomics parsers. Needs to have 'm/z array' and 'intensity array' keys.
+    peptide : str or None, optional
+        A modX sequence. If provided, the peaks will be annotated as peptide fragments.
+    spectrum_kws : dict or None, optional
+        Passed to :py:func:`spectrum_utils.plot.mirror`.
+    ax : matplotlib.pyplot.Axes or None, optional
+        Passed to :py:func:`spectrum_utils.plot.mirror`.
+    **kwargs : same as for :py:func:`annotate_spectrum` for `spectrum_utils` backends.
+    """
+
+    spec_gen = _spectrum_utils_create_spectrum if peptide is None else _spectrum_utils_annotate_spectrum
+    spec_top = spec_gen(spec_top, peptide, **kwargs)
+    spec_bottom = spec_gen(spec_bottom, peptide, **kwargs)
+    return sup.mirror(spec_top, spec_bottom, spectrum_kws=spectrum_kws, ax=ax)

--- a/pyteomics/pylab_aux.py
+++ b/pyteomics/pylab_aux.py
@@ -674,6 +674,13 @@ def annotate_spectrum(spectrum, peptide, *args, **kwargs):
         A dictionary of amino acid residue masses.
     text_kw : dict, keyword only, optional
         Keyword arguments for :py:func:`pylab.text`.
+    xlabel : str, keyword only, optional
+        Label for the X axis. Default is "m/z".
+    ylabel : str, keyword only, optional
+        Label for the Y axis. Default is "intensity".
+    title : str, keyword only, optional
+        The title. Empty by default.
+
     *args
         Passed to the plotting backend.
     **kwargs
@@ -729,6 +736,9 @@ def annotate_spectrum(spectrum, peptide, *args, **kwargs):
     if backend is None:
         raise PyteomicsError('Unknown backend name: {}. Should be one of: {}.'.format(
             bname, '; '.join(_annotation_backends)))
+    pylab.xlabel(kwargs.pop('xlabel', 'm/z'))
+    pylab.ylabel(kwargs.pop('ylabel', 'intensity'))
+    pylab.title(kwargs.pop('title', ''))
     return backend(spectrum, peptide, *args, **kwargs)
 
 
@@ -750,10 +760,22 @@ def mirror(spec_top, spec_bottom, peptide=None, spectrum_kws=None, ax=None, **kw
         Passed to :py:func:`spectrum_utils.plot.mirror`.
     ax : matplotlib.pyplot.Axes or None, optional
         Passed to :py:func:`spectrum_utils.plot.mirror`.
+    xlabel : str, keyword only, optional
+        Label for the X axis. Default is "m/z".
+    ylabel : str, keyword only, optional
+        Label for the Y axis. Default is "intensity".
+    title : str, keyword only, optional
+        The title. Empty by default.
+
     **kwargs : same as for :py:func:`annotate_spectrum` for `spectrum_utils` backends.
     """
 
     spec_gen = _spectrum_utils_create_spectrum if peptide is None else _spectrum_utils_annotate_spectrum
     spec_top = spec_gen(spec_top, peptide, **kwargs)
     spec_bottom = spec_gen(spec_bottom, peptide, **kwargs)
-    return sup.mirror(spec_top, spec_bottom, spectrum_kws=spectrum_kws, ax=ax)
+
+    ax = sup.mirror(spec_top, spec_bottom, spectrum_kws=spectrum_kws, ax=ax)
+    ax.set_xlabel(kwargs.pop('xlabel', 'm/z'))
+    ax.set_ylabel(kwargs.pop('ylabel', 'intensity'))
+    ax.set_title(kwargs.pop('title', ''))
+    return ax


### PR DESCRIPTION
@bittremieux I'm thinking of adding integration with [spectrum_utils](https://github.com/bittremieux/spectrum_utils) to `pylab_aux.annotate_spectrum`. What do you think?

The idea is to take the work of transforming the spectra from `pyteomics` format to `spectrum_utils` off the user. It can be tested with the following (based on [spectrum_utils doc](https://spectrum-utils.readthedocs.io/en/latest/quickstart.html)):

```python
from pyteomics import pylab_aux as pa, usi
spectrum = usi.proxi('mzspec:PXD004732:01650b_BC2-TUM_first_pool_53_01_01-3xHCD-1h-R2:scan:41840', 'massive')
peptide = 'WNQLQAFWGTGK'

pa.annotate_spectrum(spectrum, peptide, precursor_charge=2, backend='spectrum_utils',
     scaling='root', min_intensity=0.05, ion_types='aby', remove_precursor_peak=True, colors={'a': 'yellow'})
```

