### PR TITLE
Properly detect non-standard array name when it is a term value

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install numpy
         pip install -r test-requirements.txt
     - name: Run the tests
       run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -25,9 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install numpy
-        pip install lxml sqlalchemy pandas cython h5py hdf5plugin
-        pip install pynumpress
+        pip install -r test-requirements.txt
     - name: Run the tests
       run: |
         cd tests; find . -name 'test_*.py' -print0 | xargs -0 -n1 env PYTHONPATH=.. python

--- a/pyteomics/mzml.py
+++ b/pyteomics/mzml.py
@@ -158,11 +158,9 @@ class MzML(xml.ArrayConversionMixin, aux.TimeOrderedIndexedReaderMixin, xml.Mult
                     candidates.append(k)
         # A non-standard data array term key might have the name for the data array
         # as the value.
-        has_nonstandard_name = info.get(NON_STANDARD_DATA_ARRAY)
-        if has_nonstandard_name:
-            is_non_standard = True
-            # We could short-circuit and return here
-            candidates.append(has_nonstandard_name)
+        nonstandard_name = info.get(NON_STANDARD_DATA_ARRAY)
+        if nonstandard_name:
+            return nonstandard_name
         if isinstance(info.get('name'), list):
             for val in info['name']:
                 if val.endswith(' array'):

--- a/pyteomics/mzml.py
+++ b/pyteomics/mzml.py
@@ -83,11 +83,26 @@ STANDARD_ARRAYS = set([
     'flow rate array',
     'pressure array',
     'temperature array',
-    'mean drift time array',
     'mean charge array',
     'resolution array',
-    'baseline array'
-])
+    'baseline array',
+    'noise array',
+    'sampled noise m/z array',
+    'sampled noise intensity array',
+    'sampled noise baseline array',
+    'ion mobility array',
+    'deconvoluted ion mobility drift time array',
+    'deconvoluted inverse reduced ion mobility array',
+    'deconvoluted ion mobility array',
+    'raw ion mobility drift time array',
+    'raw inverse reduced ion mobility array',
+    'raw ion mobility array',
+    'mean inverse reduced ion mobility array',
+    'mean ion mobility array',
+    'mean ion mobility drift time array',
+    'mass array',
+    'scanning quadrupole position lower bound m/z array',
+    'scanning quadrupole position upper bound m/z array',])
 
 
 class MzML(xml.ArrayConversionMixin, aux.TimeOrderedIndexedReaderMixin, xml.MultiProcessingXML, xml.IndexSavingXML):
@@ -141,6 +156,13 @@ class MzML(xml.ArrayConversionMixin, aux.TimeOrderedIndexedReaderMixin, xml.Mult
                     is_non_standard = True
                 else:
                     candidates.append(k)
+        # A non-standard data array term key might have the name for the data array
+        # as the value.
+        has_nonstandard_name = info.get(NON_STANDARD_DATA_ARRAY)
+        if has_nonstandard_name:
+            is_non_standard = True
+            # We could short-circuit and return here
+            candidates.append(has_nonstandard_name)
         if isinstance(info.get('name'), list):
             for val in info['name']:
                 if val.endswith(' array'):
@@ -180,9 +202,13 @@ class MzML(xml.ArrayConversionMixin, aux.TimeOrderedIndexedReaderMixin, xml.Mult
         # make a good choice here. We first prefer the standardized
         # arrays before falling back to just guessing.
         else:
+            candidates = set(candidates)
+            # Maybe we just have a repeated term?
+            if len(candidates) == 1:
+                return next(iter(candidates))
             warnings.warn(
                 "Multiple options for naming binary array: %r" % candidates)
-            standard_options = set(candidates) & STANDARD_ARRAYS
+            standard_options = candidates & STANDARD_ARRAYS
             if standard_options:
                 return max(standard_options, key=len)
             return max(candidates, key=len)

--- a/pyteomics/mzml.py
+++ b/pyteomics/mzml.py
@@ -102,7 +102,8 @@ STANDARD_ARRAYS = set([
     'mean ion mobility drift time array',
     'mass array',
     'scanning quadrupole position lower bound m/z array',
-    'scanning quadrupole position upper bound m/z array',])
+    'scanning quadrupole position upper bound m/z array',
+])
 
 
 class MzML(xml.ArrayConversionMixin, aux.TimeOrderedIndexedReaderMixin, xml.MultiProcessingXML, xml.IndexSavingXML):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,10 @@
+lxml
+numpy
+matplotlib
+pandas
+sqlalchemy
+cython
+h5py
+hdf5plugin < 3.0.0; python_version < '3'
+hdf5plugin; python_version > '3.1'
+pynumpress


### PR DESCRIPTION
Right now, we can detect a mzML binary data array non-standard data array's name if it is a userParam with the word "array" in its name.
```xml
<binaryDataArray encodedLength="20">
  <cvParam cvRef="PSI-MS" accession="MS:1000786" name="non-standard data array"/>
  <userParam name="frobnication wavelength array"/>
  <cvParam cvRef="PSI-MS" accession="MS:1000574" name="zlib compression" value=""/>
  <cvParam cvRef="PSI-MS" accession="MS:1000521" name="32-bit float" value=""/>
  <binary>eJxjYGiwZxhBGADvOCzF</binary>
</binaryDataArray>
```
It might also be the value of the "non-standard data array" cvParam according to the spec and CV:
```xml
<binaryDataArray encodedLength="20">
  <cvParam cvRef="PSI-MS" accession="MS:1000786" name="non-standard data array" value="frobnication wavelength array"/>
  <cvParam cvRef="PSI-MS" accession="MS:1000574" name="zlib compression" value=""/>
  <cvParam cvRef="PSI-MS" accession="MS:1000521" name="32-bit float" value=""/>
  <binary>eJxjYGiwZxhBGADvOCzF</binary>
</binaryDataArray>
```
Currently, we would just return `"non-standard data array"` when evaluating the second example. This PR makes it properly return the non-standard name.

I also updated the array name set as several new ion-mobility related array types have been added. These names are only used as a last resort when trying to determine which term really represents the array's name.

