### PR TITLE
Fix ProForma Parsing and Update Docs

### DIFF
--- a/pyteomics/proforma.py
+++ b/pyteomics/proforma.py
@@ -1628,7 +1628,7 @@ def parse(sequence):
         elif state == POST_GLOBAL_AA:
             if c in VALID_AA:
                 current_aa_targets.append(c)
-            if c == ',':
+            elif c == ',':
                 # the next character should be another amino acid
                 pass
             elif c == '>':

--- a/pyteomics/proforma.py
+++ b/pyteomics/proforma.py
@@ -1628,6 +1628,9 @@ def parse(sequence):
         elif state == POST_GLOBAL_AA:
             if c in VALID_AA:
                 current_aa_targets.append(c)
+            if c == ',':
+                # the next character should be another amino acid
+                pass
             elif c == '>':
                 fixed_modifications.append(
                     ModificationRule(current_tag()[0], current_aa_targets()))
@@ -1792,6 +1795,30 @@ class ProForma(object):
     Attributes
     ----------
     sequence : list[tuple[]]
+        The list of (amino acid, tag collection) pairs making up the primary sequence of the
+        peptide.
+    isotopes : list[StableIsotope]
+        A list of any stable isotope rules that apply to this peptide
+    charge_state : int, optional
+        An optional charge state that may have been provided
+    intervals : list[Interval]
+        Any annotated intervals that contain either sequence ambiguity or a
+        tag over that interval.
+    labile_modifications : list[ModificationBase]
+        Any modifications that were parsed as labile, and may not appear at
+        any location on the peptide primary sequence.
+    unlocalized_modifications : list[ModificationBase]
+        Any modifications that were not localized but may be attached to peptide
+        sequence evidence.
+    n_term : list[ModificationBase]
+        Any modifications on the N-terminus of the peptide
+    c_term : list[ModificationBase]
+        Any modifications on the C-terminus of the peptide
+    group_ids : set
+        The collection of all groupd identifiers on this sequence.
+    mass : float
+        The computed mass for the fully modified peptide, including labile
+        and unlocalized modifications. **Does not include stable isotopes at this time**
     '''
 
     def __init__(self, sequence, properties):
@@ -1899,6 +1926,8 @@ class ProForma(object):
         return mass
 
     def find_tags_by_id(self, tag_id, include_position=True):
+        '''Find all occurrences of a particular
+        '''
         if not tag_id.startswith("#"):
             tag_id = "#" + tag_id
         matches = []

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ extras_require = {'XML': ['lxml', 'numpy'],
                   'DF': ['pandas'],
                   'Unimod': ['lxml', 'sqlalchemy'],
                   'numpress': ['pynumpress'],
-                  'mzMLb': ['h5py', 'hdf5plugin']}
+                  'mzMLb': ['h5py', 'hdf5plugin'],
+                  'proforma': ['psims > v0.1.42']}
 extras_require['all'] = sum(extras_require.values(), [])
 
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,4 +8,4 @@ h5py
 hdf5plugin < 3.0.0; python_version < '3'
 hdf5plugin; python_version > '3.1'
 pynumpress
-psims
+psims > 0.1.42

--- a/tests/test_proforma.py
+++ b/tests/test_proforma.py
@@ -1,14 +1,11 @@
-
-from ast import parse
 from os import path
 import unittest
 import pyteomics
 pyteomics.__path__ = [path.abspath(
     path.join(path.dirname(__file__), path.pardir, 'pyteomics'))]
-from pyteomics import proforma
 from pyteomics.proforma import (
-    ProForma, TaggedInterval, parse, MassModification,
-    ModificationRule, StableIsotope, GenericModification, to_proforma,
+    ProForma, TaggedInterval, parse, MassModification, ProFormaError, TagTypeEnum,
+    ModificationRule, StableIsotope, GenericModification, Composition, to_proforma,
     obo_cache)
 
 
@@ -31,23 +28,21 @@ class ProFormaTest(unittest.TestCase):
         self.assertAlmostEqual(
             ProForma(tokens, properties).mass, 1210.5088, 3)
 
-
     def test_range(self):
         seq = "PRQT(EQC[Carbamidomethyl]FQRMS)[+19.0523]ISK"
-        parsed = proforma.ProForma.parse(seq)
+        parsed = ProForma.parse(seq)
         assert str(parsed) == seq
         chunk = parsed[:6]
         assert chunk.intervals
 
     def test_ambiguous_range(self):
         seq = "PRQT(?EQC[Carbamidomethyl]FQRMS)ISK"
-        parsed = proforma.ProForma.parse(seq)
+        parsed = ProForma.parse(seq)
         assert str(parsed) == seq
         self.assertRaises(ValueError, lambda: parsed[:6])
 
-
     def test_error_on_nested_range(self):
-        self.assertRaises(proforma.ProFormaError, lambda: parse(
+        self.assertRaises(ProFormaError, lambda: parse(
             "PRQT(EQ(CFQR)[Carbamidomethyl]MS)[+19.0523]ISK"))
 
     def test_localization_scores(self):
@@ -56,14 +51,14 @@ class ProFormaTest(unittest.TestCase):
         tags = obj.find_tags_by_id("#g1")
         solutions = {4: 0.01, 5: 0.09, 7: 0.9}
         for i, tag in tags:
-            marker = tag.find_tag_type(proforma.TagTypeEnum.localization_marker)[0]
+            marker = tag.find_tag_type(TagTypeEnum.localization_marker)[0]
             expected = solutions[i]
             assert expected == marker.value
 
     def test_multiple_info(self):
-        i = proforma.ProForma.parse(
+        i = ProForma.parse(
             "ELVIS[Phospho|INFO:newly discovered|info:really awesome]K")
-        tags = i[4][1][0].find_tag_type(proforma.TagTypeEnum.info)
+        tags = i[4][1][0].find_tag_type(TagTypeEnum.info)
         messages = set(['newly discovered', 'really awesome'])
         assert len(tags) == 2
         for tag in tags:
@@ -71,17 +66,17 @@ class ProFormaTest(unittest.TestCase):
         assert len(messages) == 0
 
     def test_formula(self):
-        i = proforma.ProForma.parse("SEQUEN[Formula:[13C2]CH6N]CE")
+        i = ProForma.parse("SEQUEN[Formula:[13C2]CH6N]CE")
         mod = i[-3][1][0]
-        assert mod.composition == proforma.Composition(
+        assert mod.composition == Composition(
             {'H': 6, 'C[13]': 2, 'C': 1, 'N': 1})
 
     def test_gnome(self):
-        gp = proforma.ProForma.parse("NEEYN[GNO:G59626AS]K")
+        gp = ProForma.parse("NEEYN[GNO:G59626AS]K")
         self.assertAlmostEqual(gp.mass, 2709.016, 3)
 
     def test_glycan(self):
-        gp = proforma.ProForma.parse("NEEYN[Glycan:Hex5HexNAc4NeuAc1]K")
+        gp = ProForma.parse("NEEYN[Glycan:Hex5HexNAc4NeuAc1]K")
         self.assertAlmostEqual(gp.mass, 2709.016, 3)
 
 


### PR DESCRIPTION
@bittremieux highlighted a few cases that were vague in the specification, and it turns out my parser didn't handle them correctly.

Also, recent changes to `psims` cause it to do more aggressive type coercion of CV terms, removing the need to do it in the `proforma` module itself. I've updated the minimum version required for the `proforma` feature to reflect this.

While there, I added a bit more documentation.