### PR TITLE
Shuffling that preserves some amino acids

### DIFF
--- a/pyteomics/fasta.py
+++ b/pyteomics/fasta.py
@@ -664,7 +664,7 @@ def reverse(sequence, keep_nterm=False, keep_cterm=False):
     return sequence[:start] + sequence[start:end][::-1] + sequence[end:]
 
 
-def shuffle(sequence, keep_nterm=False, keep_cterm=False):
+def shuffle(sequence, keep_nterm=False, keep_cterm=False, keep_M=False, fix_aa=''):
     """
     Create a decoy sequence by shuffling the original one.
 
@@ -678,22 +678,54 @@ def shuffle(sequence, keep_nterm=False, keep_cterm=False):
     keep_cterm : bool, optional
         If :py:const:`True`, then the C-terminal residue will be kept.
         Default is :py:const:`False`.
-
+    keep_M : bool, optional
+        If :py:const:`True`, then the C-terminal methionine will be kept.
+        Default is :py:const:`False`.
+    fix_aa : str or list or tuple, optional
+        single letter codes for amino acids that should preserve their position
+        during shuffling.
+        Default is ''.
     Returns
     -------
     decoy_sequence : str
         The decoy sequence.
     """
-    start = 1 if keep_nterm else 0
-    end = len(sequence)-1 if keep_cterm else len(sequence)
-    if start == end:
-        return sequence
-    elif keep_cterm or keep_nterm:
-        return sequence[:start] + shuffle(sequence[start:end]) + sequence[end:]
-
-    modified_sequence = list(sequence)
-    random.shuffle(modified_sequence)
-    return ''.join(modified_sequence)
+    #empty sequence
+    if len(sequence) == 0:
+        return ''
+    
+    #presereve the first position
+    if (keep_M and sequence[0] == 'M') or keep_nterm:
+        return sequence[0] + shuffle(sequence[1:], keep_cterm=keep_cterm, 
+                       fix_aa=fix_aa)
+    
+    #presereve the last position
+    if keep_cterm:
+        return shuffle(sequence[:-1], fix_aa=fix_aa) + sequence[-1]
+    
+    
+    if type(fix_aa) in [list, tuple]:
+        fix_aa = ''.join(fix_aa)
+    
+    fixed = []
+    position = 0
+    if len(fix_aa) > 0: #non-empty fixed list
+        shuffled = []
+        for match in re.finditer(r'[{}]'.format(fix_aa), sequence):
+            fixed.append((match.start(), sequence[match.start()]))
+            shuffled += list(sequence[position:match.start()])
+            position = match.end()
+        shuffled += list(sequence[position:])
+        
+    else: #shuffle everything
+        shuffled = list(sequence)
+    
+    random.shuffle(shuffled)
+    
+    for fix in fixed:
+        shuffled.insert(fix[0], fix[1])
+    
+    return ''.join(shuffled)
 
 
 def fused_decoy(sequence, decoy_mode='reverse', sep='R', **kwargs):

--- a/pyteomics/fasta.py
+++ b/pyteomics/fasta.py
@@ -664,7 +664,7 @@ def reverse(sequence, keep_nterm=False, keep_cterm=False):
     return sequence[:start] + sequence[start:end][::-1] + sequence[end:]
 
 
-def shuffle(sequence, keep_nterm=False, keep_cterm=False, keep_M=False, fix_aa=''):
+def shuffle(sequence, keep_nterm=False, keep_cterm=False, keep_nterm_M=False, fix_aa=''):
     """
     Create a decoy sequence by shuffling the original one.
 
@@ -678,46 +678,48 @@ def shuffle(sequence, keep_nterm=False, keep_cterm=False, keep_M=False, fix_aa='
     keep_cterm : bool, optional
         If :py:const:`True`, then the C-terminal residue will be kept.
         Default is :py:const:`False`.
-    keep_M : bool, optional
-        If :py:const:`True`, then the C-terminal methionine will be kept.
+    keep_nterm_M : bool, optional
+        If :py:const:`True`, then the N-terminal methionine will be kept.
         Default is :py:const:`False`.
-    fix_aa : str or list or tuple, optional
-        single letter codes for amino acids that should preserve their position
+    fix_aa : iterable, optional
+        Single letter codes for amino acids that should preserve their position
         during shuffling.
         Default is ''.
+
     Returns
     -------
     decoy_sequence : str
         The decoy sequence.
     """
-    #empty sequence
+
+    # empty sequence
     if len(sequence) == 0:
         return ''
     
-    #presereve the first position
-    if (keep_M and sequence[0] == 'M') or keep_nterm:
+    # presereve the first position
+    if (keep_nterm_M and sequence[0] == 'M') or keep_nterm:
         return sequence[0] + shuffle(sequence[1:], keep_cterm=keep_cterm, 
                        fix_aa=fix_aa)
     
-    #presereve the last position
+    # presereve the last position
     if keep_cterm:
         return shuffle(sequence[:-1], fix_aa=fix_aa) + sequence[-1]
     
     
-    if type(fix_aa) in [list, tuple]:
+    if not isinstance(fix_aa, str):
         fix_aa = ''.join(fix_aa)
     
     fixed = []
     position = 0
-    if len(fix_aa) > 0: #non-empty fixed list
+    if len(fix_aa) > 0:  # non-empty fixed list
         shuffled = []
         for match in re.finditer(r'[{}]'.format(fix_aa), sequence):
             fixed.append((match.start(), sequence[match.start()]))
-            shuffled += list(sequence[position:match.start()])
+            shuffled.extend(sequence[position:match.start()])
             position = match.end()
-        shuffled += list(sequence[position:])
+        shuffled.extend(sequence[position:])
         
-    else: #shuffle everything
+    else:  # shuffle everything
         shuffled = list(sequence)
     
     random.shuffle(shuffled)

--- a/tests/test_fasta.py
+++ b/tests/test_fasta.py
@@ -4,6 +4,7 @@ import unittest
 import random
 import string
 import pickle
+import re
 import pyteomics
 pyteomics.__path__ = [path.abspath(path.join(path.dirname(__file__), path.pardir, 'pyteomics'))]
 from pyteomics import fasta
@@ -81,6 +82,16 @@ class FastaTest(unittest.TestCase):
         for s in sequences:
             ss = fasta.shuffle(s)
             self.assertEqual(sorted(list(s)), sorted(list(ss)))
+            if not all(a == b for a, b in zip(s, ss)):
+                test = False
+        self.assertFalse(test)
+        
+        test = True
+        for s in sequences:
+            aa = random.choice(string.ascii_uppercase)
+            ss = fasta.shuffle(s, fix_aa=aa)
+            self.assertEqual([_.span() for _ in re.finditer(aa, s)],
+                              [_.span() for _ in re.finditer(aa, ss)])
             if not all(a == b for a, b in zip(s, ss)):
                 test = False
         self.assertFalse(test)

--- a/tests/test_fasta.py
+++ b/tests/test_fasta.py
@@ -5,6 +5,7 @@ import random
 import string
 import pickle
 import re
+from collections import Counter
 import pyteomics
 pyteomics.__path__ = [path.abspath(path.join(path.dirname(__file__), path.pardir, 'pyteomics'))]
 from pyteomics import fasta
@@ -88,10 +89,14 @@ class FastaTest(unittest.TestCase):
         
         test = True
         for s in sequences:
-            aa = random.choice(string.ascii_uppercase)
-            ss = fasta.shuffle(s, fix_aa=aa)
-            self.assertEqual([_.span() for _ in re.finditer(aa, s)],
-                              [_.span() for _ in re.finditer(aa, ss)])
+            n = random.randint(1, 5)
+            fix_aa = [random.choice(string.ascii_uppercase) for _ in range(n)]
+            ss = fasta.shuffle(s, fix_aa=fix_aa)
+            self.assertEqual(len(s), len(ss))
+            self.assertEqual(Counter(s), Counter(ss))
+            for aa in fix_aa:
+                self.assertEqual([_.span() for _ in re.finditer(aa, s)],
+                                  [_.span() for _ in re.finditer(aa, ss)])
             if not all(a == b for a, b in zip(s, ss)):
                 test = False
         self.assertFalse(test)


### PR DESCRIPTION
Shuffle function in fasta module is updated to include two new argument
`keep_M` preserve **only** N-terminal methionine
`fix_aa` allows excluding some of amino acids from shuffling (i.e. position is preserved)