### PR TITLE
Handle cases where the PROXI server responds with properly typed numerical values for attributes

### DIFF
--- a/pyteomics/usi.py
+++ b/pyteomics/usi.py
@@ -200,7 +200,7 @@ class _PROXIBackend(object):
         result = {}
         result['attributes'] = data.pop('attributes', [])
         for attrib in result['attributes']:
-            if 'value' in attrib and attrib['value'][0].isdigit():
+            if 'value' in attrib and isinstance(attrib['value'], str) and attrib['value'][0].isdigit():
                 try:
                     attrib['value'] = cast_numeric(attrib['value'])
                 except TypeError:


### PR DESCRIPTION
I noticed a service started to respond with integer and float values for attributes, which broke the attribute type coercion code. This fixes the issue, making the code work on both cases.