### PR TITLE
Document the unit handling and controlled vocabulary string features

### DIFF
--- a/doc/source/api/auxiliary.rst
+++ b/doc/source/api/auxiliary.rst
@@ -57,5 +57,6 @@ Helpers
 .. automodule :: pyteomics.auxiliary.utils
 
 .. automodule :: pyteomics.auxiliary.structures
+  :exclude-members: unitint, unitfloat, unitstr, cvstr, CVQueryEngine
 
 .. automodule :: pyteomics.auxiliary.file_helpers

--- a/doc/source/data.rst
+++ b/doc/source/data.rst
@@ -19,3 +19,7 @@ results and protein databases.
 .. include :: data/indexing.rst.inc
 
 .. include :: data/tda.rst.inc
+
+.. include :: data/controlled_vocabulary_terms.rst.inc
+
+.. include :: data/unit_handling.rst.inc

--- a/doc/source/data/controlled_vocabulary_terms.rst.inc
+++ b/doc/source/data/controlled_vocabulary_terms.rst.inc
@@ -1,0 +1,91 @@
+Controlled Vocabulary Terms In Structured Data
+==============================================
+When parsing files with controlled vocabulary terms, especially in positions where
+those terms may be used as keys, :mod:`pyteomics` will use an instance of :class:`~.pyteomics.auxiliary.structures.cvstr`
+to represent that value. A :class:`~.pyteomics.auxiliary.structures.cvstr` is a sub-class of :class:`str`
+with two additional attributes storing the accession number of the term it names, and another
+holding the accession number of the unit of its value, if any.
+
+.. autoclass:: pyteomics.auxiliary.structures.cvstr
+    :no-inherited-members:
+
+Accessing the attributes of a :class:`dict` key to find out if it matches a query
+is inconvenient. To handle looking up a value by accession, the :class:`~pyteomics.auxiliary.structures.CVQueryEngine`
+type can help solve the problem by either looking up a single accession value, or
+convert a nested :class:`dict` structure with :class:`~.cvstr` as keys into a :class:`dict`
+with accession numbers as keys, mapping to the value their owners pointed to in the original
+:class:`dict`, or their naming :class:`str` if the value is empty:
+
+For example, if we had parsed an mzML file, and read out a spectrum:
+
+.. code:: python
+
+    >>> from pyteomics import mzml
+    >>> scan = next(mzml.read("tests/test.mzml"))
+    >>> scan
+    {'index': 0,
+    'id': 'controllerType=0 controllerNumber=1 scan=1',
+    'defaultArrayLength': 19914,
+    'scanList': {'count': 1,
+    'scan': [{'instrumentConfigurationRef': 'IC1',
+        'scanWindowList': {'count': 1,
+        'scanWindow': [{'scan window lower limit': 200.0 m/z,
+        'scan window upper limit': 2000.0 m/z}]},
+        'scan start time': 0.004935 minute,
+        'filter string': 'FTMS + p ESI Full ms [200.00-2000.00]',
+        'preset scan configuration': 1.0,
+        '[Thermo Trailer Extra]Monoisotopic M/Z:': 810.4152221679688}],
+    'no combination': ''},
+    'ms level': 1,
+    'MSn spectrum': '',
+    'positive scan': '',
+    'profile spectrum': '',
+    'base peak m/z': 810.415283203125 m/z,
+    'base peak intensity': 1471973.875 number of counts,
+    'total ion current': 15245068.0,
+    'lowest observed m/z': 200.00018816645022 m/z,
+    'highest observed m/z': 2000.0099466203771 m/z,
+    'count': 2,
+    'm/z array': array([ 200.00018817,  200.00043034,  200.00067252, ..., 1999.96151259,
+            1999.98572931, 2000.00994662]),
+    'intensity array': array([0., 0., 0., ..., 0., 0., 0.], dtype=float32)}
+
+Then :obj:`cvquery(scan)` would yield the following look up table:
+
+.. code:: python
+
+    >>> from pyteomics.auxiliary import cvquery
+    >>> cvquery(scan)
+    {'MS:1000501': 200.0 m/z,
+     'MS:1000500': 2000.0 m/z,
+     'MS:1000016': 0.004935 minute,
+     'MS:1000512': 'FTMS + p ESI Full ms [200.00-2000.00]',
+     'MS:1000616': 1.0,
+     'MS:1000795': 'no combination',
+     'MS:1000511': 1,
+     'MS:1000580': 'MSn spectrum',
+     'MS:1000130': 'positive scan',
+     'MS:1000128': 'profile spectrum',
+     'MS:1000504': 810.415283203125 m/z,
+     'MS:1000505': 1471973.875 number of counts,
+     'MS:1000285': 15245068.0,
+     'MS:1000528': 200.00018816645022 m/z,
+     'MS:1000527': 2000.0099466203771 m/z,
+     'MS:1000514': array([ 200.00018817,  200.00043034,  200.00067252, ..., 1999.96151259,
+             1999.98572931, 2000.00994662]),
+     'MS:1000515': array([0., 0., 0., ..., 0., 0., 0.], dtype=float32)}
+
+Alternatively, if we have a particular accession in mind, e.g. :obj:`MS:1000016` for :obj:`"scan start time"`, we could query for
+that specifically:
+
+.. code:: python
+
+    >>> cvquery(scan, "MS:1000016")
+    0.004935
+
+Because :class:`~pyteomics.auxiliary.structures.CVQueryEngine` does not have any state of its own,
+we use a pre-made instance, :obj:`pyteomics.auxiliary.structures.cvquery`.
+
+.. autofunction:: pyteomics.auxiliary.structures.cvquery
+
+.. autoclass:: pyteomics.auxiliary.structures.CVQueryEngine

--- a/doc/source/data/unit_handling.rst.inc
+++ b/doc/source/data/unit_handling.rst.inc
@@ -1,0 +1,79 @@
+Unit Handling
+=============
+
+When parsing parsing a data file with unit information associated with a scalar value,
+:mod:`pyteomics` uses annotated data types to carry units around, with the specific type
+determined by parsing the value.
+
+For instance, given the XML string:
+
+.. code:: xml
+
+    <cvParam cvRef="MS" accession="MS:1000927" name="ion injection time" value="68.227485656738"
+             unitCvRef="UO" unitAccession="UO:0000028" unitName="millisecond"/>
+
+This will be parsed into a :class:`~.unitfloat`:
+
+.. code:: python
+
+    >>> value = unitfloat(68.227485656738, "millisecond")
+    # Get the unit name, perhaps to do a conversion to another unit
+    >>> value.unit_info
+    "millisecond"
+    # Can be coerced into a plain float without issue
+    >>> float(value)
+    68.227485656738
+    # Can be used identically to a normal float
+    >>> value > 50.0 and value < 90.0
+    True
+
+To normalize the time unit, we can write a function like this:
+
+.. code:: python
+
+    from pyteomics.auxiliary import unitfloat
+
+    def in_minutes(x):
+        '''Convert a time quantity to minutes
+
+        Parameters
+        ----------
+        x: unitfloat
+            A float representing a quantity of time annotated with a time unit
+
+        Returns
+        -------
+        unitfloat:
+            The time after conversion to minutes
+        '''
+        try:
+            unit = x.unit_info
+        except AttributeError:
+            return x
+        if unit == 'minute':
+            return x
+        elif unit == 'second':
+            y = unitfloat(x / 60., 'minute')
+            return y
+        elif unit == 'hour':
+            y = unitfloat(x * 60, 'minute')
+            return y
+        else:
+            warnings.warn("Time unit %r not recognized" % unit)
+        return x
+
+.. code:: python
+
+    >>> seconds = unitfloat(93.5, "seconds")
+    >>> minutes = in_minutes(seconds)
+    >>> minutes
+    1.55833
+
+.. autoclass:: pyteomics.auxiliary.structures.unitfloat
+    :no-inherited-members:
+
+.. autoclass:: pyteomics.auxiliary.structures.unitint
+    :no-inherited-members:
+
+.. autoclass:: pyteomics.auxiliary.structures.unitstr
+    :no-inherited-members:

--- a/pyteomics/auxiliary/structures.py
+++ b/pyteomics/auxiliary/structures.py
@@ -264,10 +264,18 @@ class _MappingOverAttributeProxy(object):
 
 
 class unitint(int):
+    '''Represents an integer value with a unit name.
 
+    Behaves identically to a built-in :class:`int` type.
+
+    Attributes
+    ----------
+    unit_info : :class:`str`
+        The name of the unit this value posseses.
+    '''
     def __new__(cls, value, unit_info=None):
         inst = int.__new__(cls, value)
-        inst.unit_info = (unit_info)
+        inst.unit_info = unit_info
         return inst
 
     def __reduce__(self):
@@ -283,6 +291,15 @@ class unitint(int):
 
 
 class unitfloat(float):
+    '''Represents an float value with a unit name.
+
+    Behaves identically to a built-in :class:`float` type.
+
+    Attributes
+    ----------
+    unit_info : :class:`str`
+        The name of the unit this value posseses.
+    '''
     __slots__ = ('unit_info', )
 
     def __new__(cls, value, unit_info=None):
@@ -307,6 +324,15 @@ class unitfloat(float):
 
 
 class unitstr(str):
+    '''Represents an string value with a unit name.
+
+    Behaves identically to a built-in :class:`str` type.
+
+    Attributes
+    ----------
+    unit_info : :class:`str`
+        The name of the unit this value posseses.
+    '''
     if not PY2:
         __slots__ = ("unit_info", )
 
@@ -335,7 +361,15 @@ class unitstr(str):
 
 class cvstr(str):
     '''A helper class to associate a controlled vocabullary accession
-    number with an otherwise plain :class:`str` object'''
+    number with an otherwise plain :class:`str` object
+
+    Attributes
+    ----------
+    accession : str
+        The accession number for this parameter, e.g. MS:1000040
+    unit_accession : str
+        The accession number for the unit of the value, if any
+    '''
 
     if not PY2:
         __slots__ = ('accession', 'unit_accession')
@@ -466,5 +500,5 @@ class CVQueryEngine(object):
         else:
             return self.query(data, accession)
 
-
+'''A ready-to-use instance of :class:`~.CVQueryEngine`'''
 cvquery = CVQueryEngine()

--- a/pyteomics/mzid.py
+++ b/pyteomics/mzid.py
@@ -58,6 +58,18 @@ Target-decoy approach
   :py:func:`qvalues` - get an array of scores and local FDR values for a PSM
   set using the target-decoy approach.
 
+Controlled Vocabularies
+~~~~~~~~~~~~~~~~~~~~~~~
+mzIdentML relies on controlled vocabularies to describe its contents extensibly. See
+`Controlled Vocabulary Terms <../data.html#controlled-vocabulary-terms-in-structured-data>`_
+for more details on how they are used.
+
+Handling Time Units and Other Qualified Quantities
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+mzIdentML contains information which may be described as using a variety of different time units.
+See `Unit Handling <../data.html#unit-handling>`_ for more information.
+
+
 Deprecated functions
 --------------------
 

--- a/pyteomics/mzml.py
+++ b/pyteomics/mzml.py
@@ -34,6 +34,17 @@ Data access
   :py:func:`chain.from_iterable` - read multiple files at once, using an
   iterable of files.
 
+Controlled Vocabularies
+~~~~~~~~~~~~~~~~~~~~~~~
+mzML relies on controlled vocabularies to describe its contents extensibly. See
+`Controlled Vocabulary Terms <../data.html#controlled-vocabulary-terms-in-structured-data>`_
+for more details on how they are used.
+
+Handling Time Units and Other Qualified Quantities
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+mzML contains information which may be described as using a variety of different time units.
+See `Unit Handling <../data.html#unit-handling>`_ for more information.
+
 Deprecated functions
 --------------------
 

--- a/pyteomics/mzmlb.py
+++ b/pyteomics/mzmlb.py
@@ -30,6 +30,16 @@ Data access
   single spectrum are converted to a human-readable dict. Spectra themselves are
   stored under 'm/z array' and 'intensity array' keys.
 
+Controlled Vocabularies
+~~~~~~~~~~~~~~~~~~~~~~~
+mzMLb relies on controlled vocabularies to describe its contents extensibly. See
+`Controlled Vocabulary Terms <../data.html#controlled-vocabulary-terms-in-structured-data>`_
+for more details on how they are used.
+
+Handling Time Units and Other Qualified Quantities
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+mzMLb contains information which may be described as using a variety of different time units.
+See `Unit Handling <../data.html#unit-handling>`_ for more information.
 
 References
 ----------

--- a/pyteomics/traml.py
+++ b/pyteomics/traml.py
@@ -27,6 +27,17 @@ Data access
   :py:func:`chain.from_iterable` - read multiple files at once, using an
   iterable of files.
 
+Controlled Vocabularies
+~~~~~~~~~~~~~~~~~~~~~~~
+TraML relies on controlled vocabularies to describe its contents extensibly. See
+`Controlled Vocabulary Terms <../data.html#controlled-vocabulary-terms-in-structured-data>`_
+for more details on how they are used.
+
+Handling Time Units and Other Qualified Quantities
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+TraML contains information which may be described as using a variety of different time units.
+See `Unit Handling <../data.html#unit-handling>`_ for more information.
+
 Deprecated functions
 --------------------
 


### PR DESCRIPTION
As shown by #56, the components for handling units were not documented. This PR adds explicit documentation for these to the mzML(b), mzIdentML, and TraML pages. This also adds more text describing the `cvstr` and `cvquery` mechanisms.