### PR TITLE
DOCFIX Remove trailing "s" from example code

### DIFF
--- a/doc/source/data/unit_handling.rst.inc
+++ b/doc/source/data/unit_handling.rst.inc
@@ -64,7 +64,7 @@ To normalize the time unit, we can write a function like this:
 
 .. code:: python
 
-    >>> seconds = unitfloat(93.5, "seconds")
+    >>> seconds = unitfloat(93.5, "second")
     >>> minutes = in_minutes(seconds)
     >>> minutes
     1.55833


### PR DESCRIPTION
The unit string should have been "second", otherwise it isn't consistent with the other code in the example, or with how the UO term is named.

