### PR TITLE
Switch USI test backend

### DIFF
--- a/tests/test_usi.py
+++ b/tests/test_usi.py
@@ -25,7 +25,7 @@ class USITest(unittest.TestCase):
 class PROXITest(unittest.TestCase):
     def test_request(self):
         usi_str = "mzspec:MSV000085202:210320_SARS_CoV_2_T:scan:131256"
-        response = proxi(usi_str, backend='peptide_atlas')
+        response = proxi(usi_str, backend='massive')
 
         assert set(usi_proxi_data.keys()) <= set(response.keys())
 


### PR DESCRIPTION
This patch fixes the USI testing backend, it seems like the Peptide Atlas USI service is down, while the MassIVE service is still working. For all example USIs at http://proteomecentral.proteomexchange.org/usi/, MassIVE works while PeptideAtlas does not.