### PR TITLE
Improve documentation of Unimod loading and highlight in ProForma

### DIFF
--- a/doc/source/api/proforma.rst
+++ b/doc/source/api/proforma.rst
@@ -11,6 +11,9 @@ for more up-to-date information.
 
 Strictly speaking, this implementation supports ProForma v2.
 
+.. contents::
+    :depth: 2
+
 Data Access
 -----------
 

--- a/doc/source/api/proforma.rst
+++ b/doc/source/api/proforma.rst
@@ -1,1 +1,229 @@
-.. automodule:: pyteomics.proforma
+
+.. module:: pyteomics.proforma
+
+proforma - Proteoform and Peptidoform Notation
+==============================================
+
+ProForma is a notation for defining modified amino acid sequences using
+a set of controlled vocabularies, as well as encoding uncertain or partial
+information about localization. See `ProForma specification <https://www.psidev.info/proforma>`_
+for more up-to-date information.
+
+Strictly speaking, this implementation supports ProForma v2.
+
+Data Access
+-----------
+
+:py:func:`parse` - The primary interface for parsing ProForma strings.
+
+    >>> parse("EM[Oxidation]EVT[#g1(0.01)]S[#g1(0.09)]ES[Phospho#g1(0.90)]PEK")
+        ([('E', None),
+          ('M', [GenericModification('Oxidation', None, None)]),
+          ('E', None),
+          ('V', None),
+          ('T', [LocalizationMarker(0.01, None, '#g1')]),
+          ('S', [LocalizationMarker(0.09, None, '#g1')]),
+          ('E', None),
+          ('S',
+          [GenericModification('Phospho', [LocalizationMarker(0.9, None, '#g1')], '#g1')]),
+          ('P', None),
+          ('E', None),
+          ('K', None)],
+         {'n_term': None,
+          'c_term': None,
+          'unlocalized_modifications': [],
+          'labile_modifications': [],
+          'fixed_modifications': [],
+          'intervals': [],
+          'isotopes': [],
+          'group_ids': ['#g1']})
+
+:py:func:`to_proforma` - Format a sequence and set of properties as ProForma text.
+
+
+Classes
+-------
+
+:py:class:`ProForma` - An object oriented version of the parsing and formatting code,
+coupled with minimal information about mass and position data.
+
+    >>> seq = ProForma.parse("EM[Oxidation]EVT[#g1(0.01)]S[#g1(0.09)]ES[Phospho#g1(0.90)]PEK")
+    >>> seq
+    ProForma([('E', None), ('M', [GenericModification('Oxidation', None, None)]), ('E', None),
+              ('V', None), ('T', [LocalizationMarker(0.01, None, '#g1')]), ('S', [LocalizationMarker(0.09, None, '#g1')]),
+              ('E', None), ('S', [GenericModification('Phospho', [LocalizationMarker(0.9, None, '#g1')], '#g1')]),
+              ('P', None), ('E', None), ('K', None)],
+              {'n_term': None, 'c_term': None, 'unlocalized_modifications': [],
+               'labile_modifications': [], 'fixed_modifications': [], 'intervals': [],
+               'isotopes': [], 'group_ids': ['#g1'], 'charge_state': None}
+            )
+    >>> seq.mass
+    1360.51054400136
+    >>> seq.tags
+    [GenericModification('Oxidation', None, None),
+     LocalizationMarker(0.01, None, '#g1'),
+     LocalizationMarker(0.09, None, '#g1'),
+     GenericModification('Phospho', [LocalizationMarker(0.9, None, '#g1')], '#g1')]
+    >>> str(seq)
+    'EM[Oxidation]EVT[#g1(0.01)]S[#g1(0.09)]ES[Phospho|#g1(0.9)]PEK'
+
+Dependencies
+------------
+
+To resolve PSI-MOD, XL-MOD, and GNO identifiers, :mod:`psims` is required. By default,
+:mod:`psims` retrieves the most recent version of each controlled vocabulary from the internet, but
+includes a fall-back version to use when the network is unavailable. It can also create
+an application cache on disk.
+
+CV Disk Caching
+~~~~~~~~~~~~~~~
+ProForma uses several different controlled vocabularies (CVs) that are each versioned separately.
+Internally, the Unimod controlled vocabulary is accessed using :class:`~pyteomics.mass.mass.Unimod`
+and all other controlled vocabularies are accessed using :mod:`psims`. Unless otherwise stated,
+the machinery will download fresh copies of each CV when first queried.
+
+To avoid this slow operation, you can keep a cached copy of the CV source file on disk and tell
+:mod:`pyteomics` and :mod:`psims` where to find them:
+
+.. code-block:: python
+
+    from pyteomics import proforma
+
+    # set the path for Unimod loading via pyteomics
+    proforma.set_unimod_path("path/to/unimod.xml")
+
+    # set the cache directory for downloading and reloading OBOs via psims
+    proforma.obo_cache.cache_path = "obo/cache/dir/"
+    proforma.obo_cache.enabled = True
+
+
+Compliance Levels
+-----------------
+
+1. Base Level Support
+Represents the lowest level of compliance, this level involves providing support for:
+
+    - [x] Amino acid sequences
+    - [x] Protein modifications using two of the supported CVs/ontologies: Unimod and PSI-MOD.
+    - [x] Protein modifications using delta masses (without prefixes)
+    - [x] N-terminal, C-terminal and labile modifications.
+    - [x] Ambiguity in the modification position, including support for localisation scores.
+    - [x] INFO tag.
+
+2. Additional Separate Support
+These features are independent from each other:
+
+    - [x] Unusual amino acids (O and U).
+    - [x] Ambiguous amino acids (e.g. X, B, Z). This would include support for sequence tags of known mass (using the character X).
+    - [x] Protein modifications using delta masses (using prefixes for the different CVs/ontologies).
+    - [x] Use of prefixes for Unimod (U:) and PSI-MOD (M:) names.
+    - [x] Support for the joint representation of experimental data and its interpretation.
+
+3. Top Down Extensions
+
+    - [ ] Additional CV/ontologies for protein modifications: RESID (the prefix R MUST be used for RESID CV/ontology term names)
+    - [x] Chemical formulas (this feature occurs in two places in this list).
+
+4. Cross-Linking Extensions
+
+    - [ ]  Cross-linked peptides (using the XL-MOD CV/ontology, the prefix X MUST be used for XL-MOD CV/ontology term names).
+
+5. Glycan Extensions
+
+    - [x] Additional CV/ontologies for protein modifications: GNO (the prefix G MUST be used for GNO CV/ontology term names)
+    - [x] Glycan composition.
+    - [x] Chemical formulas (this feature occurs in two places in this list).
+
+6. Spectral Support
+
+    - [x] Charge state and adducts
+    - [ ] Chimeric spectra are special cases.
+    - [x] Global modifications (e.g., every C is C13).
+
+
+Functions
+---------
+
+.. autofunction:: parse
+
+.. autofunction:: to_proforma
+
+Helpers
+~~~~~~~
+
+.. autofunction:: set_unimod_path
+
+
+High Level Interface
+--------------------
+
+.. autoclass:: ProForma
+
+
+Tag Types
+---------
+
+.. autoclass:: TagBase
+
+.. autoclass:: TagTypeEnum
+
+
+Modification Tags
+~~~~~~~~~~~~~~~~~
+
+.. autoclass:: MassModification
+
+.. autoclass:: ModificationBase
+
+.. autoclass:: GenericModification
+
+.. autoclass:: FormulaModification
+
+.. autoclass:: UnimodModification
+
+.. autoclass:: PSIModModification
+
+.. autoclass:: XLMODModification
+
+.. autoclass:: GNOmeModification
+
+.. autoclass:: GlycanModification
+
+.. autoclass:: ModificationToken
+
+
+Label Tags
+~~~~~~~~~~
+
+.. autoclass:: InformationTag
+
+.. autoclass:: PositionLabelTag
+
+.. autoclass:: LocalizationMarker
+
+
+Supporting Types
+----------------
+
+.. autoclass:: ModificationRule
+
+.. autoclass:: StableIsotope
+
+.. autoclass:: TaggedInterval
+
+.. autoclass:: ChargeState
+
+Modification Resolvers
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: ModificationResolver
+
+.. autoclass:: GenericResolver
+
+.. autoclass:: UnimodResolver
+
+.. autoclass:: PSIModResolver
+
+.. autoclass:: XLMODResolver
+
+.. autoclass:: GNOResolver

--- a/doc/source/api/unimod.rst
+++ b/doc/source/api/unimod.rst
@@ -1,1 +1,57 @@
-.. automodule:: pyteomics.mass.unimod
+.. module:: pyteomics.mass.unimod
+
+unimod - interface to the Unimod database
+=========================================
+
+This module provides an interface to the relational Unimod database.
+The main class is :py:class:`Unimod`, which provides an identical interface
+to that of the in-memory implementation of the same name in :mod:`pyteomics.mass`.
+
+Dependencies
+------------
+
+This module requires :py:mod:`lxml` and :py:mod:`sqlalchemy`.
+
+
+Primary Interface
+-----------------
+
+    .. autoclass:: Unimod
+
+
+Relational Entities
+~~~~~~~~~~~~~~~~~~~
+There are many tables that are described as object-relationally mapped (ORM) types in this module. The most important two are shown
+here.
+
+    .. class:: Modification
+
+        A single modification record from Unimod, having an :attr:`id`, :attr:`full_name`, :attr:`code_name`,
+        and :attr:`ex_code_name` as identifiers, and :attr:`monoisotopic_mass`, :attr:`average_mass`, and
+        :attr:`composition` as mass-describing properties.
+
+        Additional relationships may be loaded through :attr:`specificities` (see :class:`~.Specificity`), :attr:`alternative_names`,
+        :attr:`fragments`, and :attr:`notes`.
+
+
+    .. class:: Specificity
+
+        Describes the relationship between a :class:`~.Modification` and an amino acid/position rule, along with the
+        chemical process type that gives rise to that modification event.
+
+Other ORM Types
+***************
+
+The following ORM types may be useful when composing a more detailed query. Additional types may be found in the source.
+
+    .. class:: AminoAcid
+
+    .. class:: Position
+
+    .. class:: Classification
+
+    .. class:: Fragment
+
+    .. class:: AlternativeName
+
+    .. class:: Crossreference

--- a/pyteomics/mass/mass.py
+++ b/pyteomics/mass/mass.py
@@ -1204,3 +1204,11 @@ class Unimod():
         return self._mods[self._id[i]]
 
     __getitem__ = by_id
+
+
+def neutral_mass(mz, z, charge_carrier=_nist_mass[PROTON][0][0]):
+    return (mz * abs(z)) - (z * charge_carrier)
+
+
+def mass_charge_ratio(neutral_mass, z, charge_carrier=_nist_mass[PROTON][0][0]):
+    return (neutral_mass + (z * charge_carrier)) / abs(z)

--- a/pyteomics/mass/unimod.py
+++ b/pyteomics/mass/unimod.py
@@ -8,7 +8,7 @@ The main class is :py:class:`Unimod`.
 Dependencies
 ------------
 
-This module requres :py:mod:`lxml` and :py:mod:`sqlalchemy`.
+This module requires :py:mod:`lxml` and :py:mod:`sqlalchemy`.
 """
 
 #   Copyright 2015 Joshua Klein, Lev Levitsky
@@ -679,6 +679,24 @@ def session(path='sqlite:///unimod.db'):
 class Unimod(object):
     """
     Main class representing the relational Unimod database.
+
+    Examples
+    --------
+
+    If you just wish to get a new copy of the data and store it in a temporary
+    in-memory database, invoking the type without parameters works without issue.
+
+    >>> new_db = Unimod()
+
+    If you want to persist a snapshot of the Unimod database to disk and query it
+    from there, or to re-use a previously downloaded database copy, pass a database
+    driver prefixed path:
+
+    >>> reused_db = Unimod("sqlite:///path/to/unimod.db")
+
+    If the path did not previously exist, a new copy of Unimod will be downloaded
+    and stored there on the first use, but be immediately available on subsequent
+    uses.
     """
     def __init__(self, path=None):
         """
@@ -765,3 +783,18 @@ class Unimod(object):
 
     def __iter__(self):
         return iter(self.session.query(Modification).yield_per(1000))
+
+    def query(self, *args):
+        '''Compose an SQL query using SQLAlchemy's ORM interface.
+
+        See :mod:`sqlalchemy`'s Session documentation for more details.
+        '''
+        return self.session.query(*args)
+
+    def execute(self, *args, **kwargs):
+        '''Execute an SQLAlchemy statement or a SQL string against the database,
+        returning the resulting database cursor.
+
+        See :mod:`sqlalchemy`'s Session documentation for more details.
+        '''
+        return self.session.execute(*args, **kwargs)

--- a/pyteomics/proforma.py
+++ b/pyteomics/proforma.py
@@ -7,138 +7,7 @@ a set of controlled vocabularies, as well as encoding uncertain or partial
 information about localization. See `ProForma specification <https://www.psidev.info/proforma>`_
 for more up-to-date information.
 
-Strictly speaking, this implementation supports ProForma v2.
-
-Data Access
------------
-
-:py:func:`parse` - The primary interface for parsing ProForma strings.
-
-    >>> parse("EM[Oxidation]EVT[#g1(0.01)]S[#g1(0.09)]ES[Phospho#g1(0.90)]PEK")
-        ([('E', None),
-          ('M', [GenericModification('Oxidation', None, None)]),
-          ('E', None),
-          ('V', None),
-          ('T', [LocalizationMarker(0.01, None, '#g1')]),
-          ('S', [LocalizationMarker(0.09, None, '#g1')]),
-          ('E', None),
-          ('S',
-          [GenericModification('Phospho', [LocalizationMarker(0.9, None, '#g1')], '#g1')]),
-          ('P', None),
-          ('E', None),
-          ('K', None)],
-         {'n_term': None,
-          'c_term': None,
-          'unlocalized_modifications': [],
-          'labile_modifications': [],
-          'fixed_modifications': [],
-          'intervals': [],
-          'isotopes': [],
-          'group_ids': ['#g1']})
-
-:py:func:`to_proforma` - Format a sequence and set of properties as ProForma text.
-
-
-Classes
--------
-
-:py:class:`ProForma` - An object oriented version of the parsing and formatting code,
-coupled with minimal information about mass and position data.
-
-    >>> seq = ProForma.parse("EM[Oxidation]EVT[#g1(0.01)]S[#g1(0.09)]ES[Phospho#g1(0.90)]PEK")
-    >>> seq
-    ProForma([('E', None), ('M', [GenericModification('Oxidation', None, None)]), ('E', None),
-              ('V', None), ('T', [LocalizationMarker(0.01, None, '#g1')]), ('S', [LocalizationMarker(0.09, None, '#g1')]),
-              ('E', None), ('S', [GenericModification('Phospho', [LocalizationMarker(0.9, None, '#g1')], '#g1')]),
-              ('P', None), ('E', None), ('K', None)],
-              {'n_term': None, 'c_term': None, 'unlocalized_modifications': [],
-               'labile_modifications': [], 'fixed_modifications': [], 'intervals': [],
-               'isotopes': [], 'group_ids': ['#g1'], 'charge_state': None}
-            )
-    >>> seq.mass
-    1360.51054400136
-    >>> seq.tags
-    [GenericModification('Oxidation', None, None),
-     LocalizationMarker(0.01, None, '#g1'),
-     LocalizationMarker(0.09, None, '#g1'),
-     GenericModification('Phospho', [LocalizationMarker(0.9, None, '#g1')], '#g1')]
-    >>> str(seq)
-    'EM[Oxidation]EVT[#g1(0.01)]S[#g1(0.09)]ES[Phospho|#g1(0.9)]PEK'
-
-Dependencies
-------------
-
-To resolve PSI-MOD, XL-MOD, and GNO identifiers, :mod:`psims` is required. By default,
-:mod:`psims` retrieves the most recent version of each controlled vocabulary from the internet, but
-includes a fall-back version to use when the network is unavailable. It can also create
-an application cache on disk.
-
-CV Disk Caching
-~~~~~~~~~~~~~~~
-ProForma uses several different controlled vocabularies (CVs) that are each versioned separately.
-Internally, the Unimod controlled vocabulary is accessed using :class:`~pyteomics.mass.mass.Unimod`
-and all other controlled vocabularies are accessed using :mod:`psims`. Unless otherwise stated,
-the machinery will download fresh copies of each CV when first queried.
-
-To avoid this slow operation, you can keep a cached copy of the CV source file on disk and tell
-:mod:`pyteomics` and :mod:`psims` where to find them:
-
-.. code-block:: python
-
-    from pyteomics import proforma
-
-    # set the path for Unimod loading via pyteomics
-    proforma.set_unimod_path("path/to/unimod.xml")
-
-    # set the cache directory for downloading and reloading OBOs via psims
-    proforma.obo_cache.cache_path = "obo/cache/dir/"
-    proforma.obo_cache.enabled = True
-
-
-Compliance Levels
------------------
-
-1. Base Level Support
-Represents the lowest level of compliance, this level involves providing support for:
-
-    - [x] Amino acid sequences
-    - [x] Protein modifications using two of the supported CVs/ontologies: Unimod and PSI-MOD.
-    - [x] Protein modifications using delta masses (without prefixes)
-    - [x] N-terminal, C-terminal and labile modifications.
-    - [x] Ambiguity in the modification position, including support for localisation scores.
-    - [x] INFO tag.
-
-2. Additional Separate Support
-These features are independent from each other:
-
-    - [x] Unusual amino acids (O and U).
-    - [x] Ambiguous amino acids (e.g. X, B, Z). This would include support for sequence tags of known mass (using the character X).
-    - [x] Protein modifications using delta masses (using prefixes for the different CVs/ontologies).
-    - [x] Use of prefixes for Unimod (U:) and PSI-MOD (M:) names.
-    - [x] Support for the joint representation of experimental data and its interpretation.
-
-3. Top Down Extensions
-
-    - [ ] Additional CV/ontologies for protein modifications: RESID (the prefix R MUST be used for RESID CV/ontology term names)
-    - [x] Chemical formulas (this feature occurs in two places in this list).
-
-4. Cross-Linking Extensions
-
-    - [ ]  Cross-linked peptides (using the XL-MOD CV/ontology, the prefix X MUST be used for XL-MOD CV/ontology term names).
-
-5. Glycan Extensions
-
-    - [x] Additional CV/ontologies for protein modifications: GNO (the prefix G MUST be used for GNO CV/ontology term names)
-    - [x] Glycan composition.
-    - [x] Chemical formulas (this feature occurs in two places in this list).
-
-6. Spectral Support
-
-    - [x] Charge state and adducts
-    - [ ] Chimeric spectra are special cases.
-    - [x] Global modifications (e.g., every C is C13).
-
-
+For more details, see the :mod:`pyteomics.proforma` online.
 '''
 
 import re
@@ -2056,6 +1925,8 @@ class _ProFormaProperty(object):
         return template.format(self=self)
 
 
+_WATER_MASS = calculate_mass(formula="H2O")
+
 class ProForma(object):
     '''Represent a parsed ProForma sequence.
 
@@ -2290,8 +2161,7 @@ class ProForma(object):
             for mod in self.properties['unlocalized_modifications']:
                 mass += mod.mass
 
-        mass += calculate_mass(formula="H")
-        mass += calculate_mass(formula="OH")
+        mass += _WATER_MASS
 
         if not reverse:
             iterator = (iter(range(0, n - 1)))

--- a/pyteomics/proforma.py
+++ b/pyteomics/proforma.py
@@ -45,13 +45,54 @@ Classes
 :py:class:`ProForma` - An object oriented version of the parsing and formatting code,
 coupled with minimal information about mass and position data.
 
+    >>> seq = ProForma.parse("EM[Oxidation]EVT[#g1(0.01)]S[#g1(0.09)]ES[Phospho#g1(0.90)]PEK")
+    >>> seq
+    ProForma([('E', None), ('M', [GenericModification('Oxidation', None, None)]), ('E', None),
+              ('V', None), ('T', [LocalizationMarker(0.01, None, '#g1')]), ('S', [LocalizationMarker(0.09, None, '#g1')]),
+              ('E', None), ('S', [GenericModification('Phospho', [LocalizationMarker(0.9, None, '#g1')], '#g1')]),
+              ('P', None), ('E', None), ('K', None)],
+              {'n_term': None, 'c_term': None, 'unlocalized_modifications': [],
+               'labile_modifications': [], 'fixed_modifications': [], 'intervals': [],
+               'isotopes': [], 'group_ids': ['#g1'], 'charge_state': None}
+            )
+    >>> seq.mass
+    1360.51054400136
+    >>> seq.tags
+    [GenericModification('Oxidation', None, None),
+     LocalizationMarker(0.01, None, '#g1'),
+     LocalizationMarker(0.09, None, '#g1'),
+     GenericModification('Phospho', [LocalizationMarker(0.9, None, '#g1')], '#g1')]
+    >>> str(seq)
+    'EM[Oxidation]EVT[#g1(0.01)]S[#g1(0.09)]ES[Phospho|#g1(0.9)]PEK'
+
 Dependencies
 ------------
 
 To resolve PSI-MOD, XL-MOD, and GNO identifiers, :mod:`psims` is required. By default,
-:mod:`psims` retrieves the most recent version of each ontology from the internet, but
+:mod:`psims` retrieves the most recent version of each controlled vocabulary from the internet, but
 includes a fall-back version to use when the network is unavailable. It can also create
 an application cache on disk.
+
+CV Disk Caching
+~~~~~~~~~~~~~~~
+ProForma uses several different controlled vocabularies (CVs) that are each versioned separately.
+Internally, the Unimod controlled vocabulary is accessed using :class:`~pyteomics.mass.mass.Unimod`
+and all other controlled vocabularies are accessed using :mod:`psims`. Unless otherwise stated,
+the machinery will download fresh copies of each CV when first queried.
+
+To avoid this slow operation, you can keep a cached copy of the CV source file on disk and tell
+:mod:`pyteomics` and :mod:`psims` where to find them:
+
+.. code-block:: python
+
+    from pyteomics import proforma
+
+    # set the path for Unimod loading via pyteomics
+    proforma.set_unimod_path("path/to/unimod.xml")
+
+    # set the cache directory for downloading and reloading OBOs via psims
+    proforma.obo_cache.cache_path = "obo/cache/dir/"
+    proforma.obo_cache.enabled = True
 
 
 Compliance Levels
@@ -104,6 +145,7 @@ import re
 import warnings
 from collections import deque, namedtuple
 from functools import partial
+from array import array as _array
 
 try:
     from enum import Enum
@@ -111,9 +153,14 @@ except ImportError:
     # Python 2 doesn't have a builtin Enum type
     Enum = object
 
-from .mass import Composition, std_aa_mass, Unimod, nist_mass, calculate_mass
+from .mass import Composition, std_aa_mass, Unimod, nist_mass, calculate_mass, std_ion_comp, mass_charge_ratio
 from .auxiliary import PyteomicsError, BasicComposition
 from .auxiliary.utils import add_metaclass
+
+try:
+    import numpy as np
+except ImportError:
+    np = None
 
 try:
     from psims.controlled_vocabulary.controlled_vocabulary import (load_psimod, load_xlmod, load_gno, obo_cache)
@@ -382,6 +429,10 @@ class ModificationResolver(object):
             self._database = self.load_database()
         return self._database
 
+    @database.setter
+    def database(self, database):
+        self._database = database
+
     def resolve(self, name=None, id=None, **kwargs):
         raise NotImplementedError()
 
@@ -431,13 +482,22 @@ class UnimodResolver(ModificationResolver):
                 raise KeyError(id)
         else:
             raise ValueError("Must provide one of `name` or `id`")
-        return {
-            'composition': defn['composition'],
-            'name': defn['title'],
-            'id': defn['record_id'],
-            'mass': defn['mono_mass'],
-            'provider': self.name
-        }
+        if isinstance(defn, dict):
+            return {
+                'composition': defn['composition'],
+                'name': defn['title'],
+                'id': defn['record_id'],
+                'mass': defn['mono_mass'],
+                'provider': self.name
+            }
+        else:
+            return {
+                "composition": defn.composition,
+                "name": defn.ex_code_name,
+                "id": defn.id,
+                "mass": defn.monoisotopic_mass,
+                "provider": self.name
+            }
 
 
 class PSIModResolver(ModificationResolver):
@@ -971,6 +1031,30 @@ class GenericModification(ModificationBase):
         raise KeyError(keys)
 
 
+def set_unimod_path(path):
+    '''Set the path to load the Unimod database from for resolving
+    ProForma Unimod modifications.
+
+    .. note::
+
+        This method ensures that the Unimod modification database loads
+        quickly from a local database file instead of downloading a new
+        copy from the internet.
+
+    Parameters
+    ----------
+    path : str or file-like object
+        A path to or file-like object for the "unimod.xml" file.
+
+    Returns
+    -------
+    :class:`~pyteomics.mass.mass.Unimod`
+    '''
+    db = Unimod(path)
+    UnimodModification.resolver.database = db
+    return db
+
+
 class ModificationToken(object):
     '''Describes a particular modification from a particular provider, independent
     of a :class:`TagBase`'s state.
@@ -1282,6 +1366,12 @@ class TaggedInterval(object):
 
     def as_slice(self):
         return slice(self.start, self.end)
+
+    def contains(self, i):
+        return self.start <= i < self.end
+
+    def __contains__(self, i):
+        return self.contains(i)
 
     def copy(self):
         return self.__class__(self.start, self.end, self.tags)
@@ -1969,9 +2059,12 @@ class _ProFormaProperty(object):
 class ProForma(object):
     '''Represent a parsed ProForma sequence.
 
+    The preferred way to instantiate this class is via the :meth:`parse`
+    method.
+
     Attributes
     ----------
-    sequence : list[tuple[]]
+    sequence : list[tuple[str, List[TagBase]]]
         The list of (amino acid, tag collection) pairs making up the primary sequence of the
         peptide.
     isotopes : list[StableIsotope]
@@ -2049,6 +2142,17 @@ class ProForma(object):
 
     @classmethod
     def parse(cls, string):
+        '''Parse a ProForma string.
+
+        Parameters
+        ----------
+        string : str
+            The string to parse
+
+        Returns
+        -------
+        ProForma
+        '''
         return cls(*parse(string))
 
     @property
@@ -2102,8 +2206,152 @@ class ProForma(object):
                 continue
         return mass
 
+    def fragments(self, ion_shift, charge=1, reverse=None, include_labile=True, include_unlocalized=True):
+        """
+        The function generates all possible fragments of the requested
+        series type.
+
+        Parameters
+        ----------
+        ion_shift : float or str
+            The mass shift of the ion series, or the name of the ion series
+        charge : int
+            The charge state of the theoretical fragment masses to generate.
+            Defaults to 1+. If 0 is passed, neutral masses will be returned.
+        reverse : bool, optional
+            Whether to fragment from the N-terminus (``False``) or C-terminus (``True``).
+            If ``ion_shift`` is a :class:`str`, the terminal will be inferred from
+            the series name. Otherwise, defaults to ``False``.
+        include_labile : bool, optional
+            Whether or not to include dissociated modification masses.
+            Defaults to ``True``
+        include_unlocalized : bool, optional
+            Whether or not to include unlocalized modification masses.
+            Defaults to ``True``
+
+        Returns
+        -------
+        np.ndarray
+
+        Examples
+        --------
+
+        >>> p = proforma.ProForma.parse("PEPTIDE")
+        >>> p.fragments('b', charge=1)
+        array([ 98.06004032, 227.1026334 , 324.15539725, 425.20307572,
+                538.2871397 , 653.31408272])
+        >>> p.fragments('y', charge=1)
+        array([148.06043424, 263.08737726, 376.17144124, 477.21911971,
+               574.27188356, 703.31447664])
+
+        """
+        if isinstance(ion_shift, str):
+            if ion_shift[0] in 'xyz':
+                reverse = True
+            ion_shift = std_ion_comp[ion_shift].mass(absolute=False)
+
+        n = len(self.sequence)
+        masses = _array('d')
+
+        mass = 0
+        mass += ion_shift
+
+        fixed_modifications = self.properties['fixed_modifications']
+        fixed_rules = {}
+        for rule in fixed_modifications:
+            for aa in rule.targets:
+                fixed_rules[aa] = rule.modification_tag.mass
+
+        intervals = self.intervals
+        if intervals:
+            intervals = sorted(intervals, key=lambda x: x.start)
+        intervals = deque(intervals)
+
+        if not include_labile:
+            for mod in self.properties['labile_modifications']:
+                mass += mod.mass
+
+        if not reverse:
+            if self.properties.get('n_term'):
+                for mod in self.properties['n_term']:
+                    try:
+                        mass += mod.mass
+                    except (AttributeError, KeyError):
+                        continue
+        else:
+            if self.properties.get('c_term'):
+                for mod in self.properties['c_term']:
+                    try:
+                        mass += mod.mass
+                    except (AttributeError, KeyError):
+                        continue
+
+        if include_unlocalized:
+            for mod in self.properties['unlocalized_modifications']:
+                mass += mod.mass
+
+        mass += calculate_mass(formula="H")
+        mass += calculate_mass(formula="OH")
+
+        if not reverse:
+            iterator = (iter(range(0, n - 1)))
+        else:
+            iterator = (reversed(range(1, n)))
+
+        for i in iterator:
+            position = self.sequence[i]
+
+            aa = position[0]
+            try:
+                mass += std_aa_mass[aa]
+            except KeyError:
+                warnings.warn("%r does not have an exact mass" % (aa, ))
+
+            if aa in fixed_rules:
+                mass += fixed_rules[aa]
+
+            tags = position[1]
+            if tags:
+                for tag in tags:
+                    try:
+                        mass += tag.mass
+                    except (AttributeError, KeyError):
+                        continue
+
+            while intervals and intervals[0].contains(i):
+                iv = intervals.popleft()
+
+                try:
+                    mass += iv.tag.mass
+                except (AttributeError, KeyError):
+                    continue
+
+            masses.append(mass)
+
+        if np is not None:
+            masses = np.asarray(masses)
+            if charge != 0:
+                return mass_charge_ratio(masses, charge)
+            return masses
+        if charge != 0:
+            for i, mass in enumerate(masses):
+                masses[i] = mass_charge_ratio(mass, charge)
+        return masses
+
     def find_tags_by_id(self, tag_id, include_position=True):
-        '''Find all occurrences of a particular
+        '''Find all occurrences of a particular tag ID
+
+        Parameters
+        ----------
+        tag_id : str
+            The tag ID to search for
+        include_position : bool
+            Whether or not to return the locations for matched
+            tag positions
+
+        Returns
+        -------
+        list[tuple[Any, TagBase]] or list[TagBase]
         '''
         if not tag_id.startswith("#"):
             tag_id = "#" + tag_id

--- a/tests/test_proforma.py
+++ b/tests/test_proforma.py
@@ -85,6 +85,24 @@ class ProFormaTest(unittest.TestCase):
         self.assertEqual(i.c_term[0].name, "Methyl")
         self.assertEqual(i[-1][1][0].name, "iTRAQ4plex")
 
+    def test_fragments(self):
+        i = ProForma.parse("PEPTIDE")
+        masses = i.fragments('b', 1)
+
+        expected = [98.06004032, 227.1026334, 324.15539725, 425.20307572,
+                    538.2871397, 653.31408272]
+
+        for o, e in zip(masses, expected):
+            self.assertAlmostEqual(o, e, 3)
+
+        masses = i.fragments('y', 1)
+        expected = [148.06043424, 263.08737726, 376.17144124, 477.21911971,
+                    574.27188356, 703.31447664]
+
+        for o, e in zip(masses, expected):
+            self.assertAlmostEqual(o, e, 3)
+
+
 
 class GenericModificationResolverTest(unittest.TestCase):
     def test_generic_resolver(self):


### PR DESCRIPTION
This PR implements some of the changes discussed in #82 but does not outright bundle the CV source file with the codebase. It adds documentation about how the CV can be loaded from disk instead of the internet.

It also re-structures the `pyteomics.proforma` documentation a bit and in need of a bit meditation I wrote a `fragments` method for the `Proforma` type.