### PR TITLE
Resolve `referenceableParamGroupRef`

### DIFF
--- a/tests/test_mzml.py
+++ b/tests/test_mzml.py
@@ -142,9 +142,11 @@ class MzmlTest(unittest.TestCase):
             derefed = list(reader.iterfind("instrumentConfiguration", retrieve_refs=True))
             reader.reset()
             raw = list(reader.iterfind("instrumentConfiguration", retrieve_refs=False))
-            self.assertEqual(raw[0].get("ref"), 'CommonInstrumentParams')
-            self.assertNotIn("ref", derefed[0])
-            self.assertEqual(derefed[0].get('instrument serial number'), 'SN06061F')
+            self.assertEqual(raw[0].get("softwareRef"),
+                             {'ref': 'Xcalibur'})
+            self.assertNotIn("ref", derefed[0]['softwareRef'])
+            self.assertEqual(derefed[0].get('softwareRef'), {
+                             'version': '1.1 Beta 7', 'Xcalibur': ''})
 
     def test_in_memory_buffer(self):
         with open(self.path, 'rb') as fh:


### PR DESCRIPTION
This change adds another special case to `XML._get_info` to treat `referenceableParamGroupRef` similar to how we treat `cvParam` and `userParam`, and then hands over responsibility for _how_ that special handling is defined to the implementing subclass, so long as the result is a `List[xml._XMLParam]`.

The implementation for mzML defers parsing `referenceableParamGroup` until you encounter a `referenceableParamGroupRef` and then does a random access seek from the start of the file parsing 

Reasons why this might not be desirable:
1. When you are reading an stream you cannot call `seek` on (e.g. `stdin` or a `socket`), you can't jump back to the start of the file to read the param group definitions.
2. Right now, `iterfind` re-scans the _whole file_. We need to add a method to halt parsing after we get to a certain element.

As noted in the discussion, this behavior is irrelevant when used with `retrieve_refs=True`, but that is not on by default.