### PR TITLE
Fix issue #98 for colon-containing mods

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+4.5.7a4
+-------
+ - Fix issue #98 by Joshua Klein
+
 4.5.7a3
 -------
 

--- a/pyteomics/proforma.py
+++ b/pyteomics/proforma.py
@@ -1103,8 +1103,16 @@ def process_tag_tokens(tokens):
         if prefix is None:
             main_tag = GenericModification(''.join(value))
         else:
-            tag_type = TagBase.find_by_tag(prefix)
-            main_tag = tag_type(value)
+            try:
+                tag_type = TagBase.find_by_tag(prefix)
+                main_tag = tag_type(value)
+            except KeyError:
+                main_tag_str = ''.join(main_tag)
+                warnings.warn(
+                    f"Possible unmatched prefix detected for {main_tag_str},"
+                     " attempting to resolve as generic modification")
+                main_tag = GenericModification(main_tag_str)
+
     if len(parts) > 1:
         extras = []
         for part in parts[1:]:
@@ -1120,8 +1128,16 @@ def process_tag_tokens(tokens):
                 else:
                     extras.append(GenericModification(''.join(value)))
             else:
-                tag_type = TagBase.find_by_tag(prefix)
-                extras.append(tag_type(value))
+                try:
+                    tag_type = TagBase.find_by_tag(prefix)
+                    extra_tag = tag_type(value)
+                except KeyError:
+                    part_str = ''.join(part)
+                    warnings.warn(
+                        f"Possible unmatched prefix detected for {part_str}"
+                         ", attempting to resolve as generic modification")
+                    extra_tag = GenericModification(part_str)
+                extras.append(extra_tag)
         main_tag.extra = extras
     return main_tag
 

--- a/tests/test_proforma.py
+++ b/tests/test_proforma.py
@@ -6,7 +6,7 @@ pyteomics.__path__ = [path.abspath(
 from pyteomics.proforma import (
     PSIModModification, ProForma, TaggedInterval, parse, MassModification, ProFormaError, TagTypeEnum,
     ModificationRule, StableIsotope, GenericModification, Composition, to_proforma, ModificationMassNotFoundError,
-    obo_cache)
+    obo_cache, process_tag_tokens)
 
 
 class ProFormaTest(unittest.TestCase):
@@ -113,6 +113,31 @@ class ProFormaTest(unittest.TestCase):
         assert i[1:].n_term is None
         assert i[1:].c_term is not None
 
+
+class TestTagProcessing(unittest.TestCase):
+    def test_process_tag_tokens(self):
+        tokens = list('UNIMOD:Deamidation')
+        tag = process_tag_tokens(tokens)
+        assert tag.value == "Deamidation"
+        assert tag.type == TagTypeEnum.unimod
+
+    def test_process_tag_tokens_generic(self):
+        tokens = list('Deamidation')
+        tag = process_tag_tokens(tokens)
+        assert tag.value == "Deamidation"
+        assert tag.type == TagTypeEnum.generic
+
+    def test_process_tag_tokens_contains_colon(self):
+        tokens = list('UNIMOD:Cation:Na')
+        tag = process_tag_tokens(tokens)
+        assert tag.value == "Cation:Na"
+        assert tag.type == TagTypeEnum.unimod
+
+    def test_process_tag_tokens_generic_contains_colon(self):
+        tokens = list('Cation:Na')
+        tag = process_tag_tokens(tokens)
+        assert tag.value == "Cation:Na"
+        assert tag.type == TagTypeEnum.generic
 
 
 class GenericModificationResolverTest(unittest.TestCase):


### PR DESCRIPTION
Closes #98 

The behavior is now to treat any colon-containing tag that doesn't have a known prefix as though it were a `GenericModification` tag. This will lead to strange behavior if we encounter a tag type that we don't support like `RESID` or `XLMOD`, with these tags being wrapped in `GenericModification` instances and then having them explode when someone tries to resolve their properties.

I can add an "unsupported list" to explicitly check those tag types and throw an error pre-emptively, but that might prevent a reasonable use-case of using `pyteomics.proforma` as a path-through between the user and some other service.