### PR TITLE
Address broader ProForma colon ambiguity

### DIFF
--- a/tests/test_proforma.py
+++ b/tests/test_proforma.py
@@ -134,10 +134,13 @@ class TestTagProcessing(unittest.TestCase):
         assert tag.type == TagTypeEnum.unimod
 
     def test_process_tag_tokens_generic_contains_colon(self):
-        tokens = list('Cation:Na')
-        tag = process_tag_tokens(tokens)
-        assert tag.value == "Cation:Na"
-        assert tag.type == TagTypeEnum.generic
+        for name in ['Cation:Na', 'Cation:Li', 'Unknown:210', 'QAT:2H(3)']:
+            tag = process_tag_tokens(list(name))
+            assert tag.value == name
+            assert tag.type == TagTypeEnum.generic
+            state = tag.resolve()
+            assert state['name'] == name
+            assert state['provider'] == 'unimod'
 
 
 class GenericModificationResolverTest(unittest.TestCase):

--- a/tests/test_proforma.py
+++ b/tests/test_proforma.py
@@ -134,7 +134,8 @@ class TestTagProcessing(unittest.TestCase):
         assert tag.type == TagTypeEnum.unimod
 
     def test_process_tag_tokens_generic_contains_colon(self):
-        for name in ['Cation:Na', 'Cation:Li', 'Unknown:210', 'QAT:2H(3)']:
+        for name in ['Cation:Na', 'Cation:Li', 'Unknown:210', 'QAT:2H(3)',
+                     'Dimethyl:2H(4)', 'Label:13C(9)', 'Cation:K']:
             tag = process_tag_tokens(list(name))
             assert tag.value == name
             assert tag.type == TagTypeEnum.generic


### PR DESCRIPTION
Fixes #99

This refactors how `:` characters are treated more broadly to address the issue in #99, moving the responsibility to the modification resolver, not the modification tag. It is an extension of #98.