### PR TITLE
Hard-code UniRef keys, remove extra fields created by str.split()

### DIFF
--- a/pyteomics/fasta.py
+++ b/pyteomics/fasta.py
@@ -461,16 +461,15 @@ class IndexedUniProt(UniProtMixin, TwoLayerIndexedFASTA):
 
 
 class UniRefMixin(FlavoredMixin):
-    header_pattern = r'^(\S+)\s+([^=]*\S)((\s+\w+=[^=]+(?!\w*=))+)\s*$'
+    header_pattern = r'^(?P<id>\S+)\s+(?P<cluster>.*?)(?:(\s+n=(?P<n>\d+))|(\s+Tax=(?P<Tax>.+?))|(\s+TaxID=(?P<TaxID>\S+))|(\s+RepID=(?P<RepID>\S+)))*\s*$'
+    header_group = 'id'
 
     def parser(self, header):
         assert 'Tax' in header
-        ID, cluster, pairs, _ = re.match(self.header_pattern, header).groups()
-        info = {'id': ID, 'cluster': cluster}
-        info.update(_split_pairs(pairs))
-        gid, taxon = info['RepID'].split('_')
-        type_, acc = ID.split('_')
-        info.update({'taxon': taxon, 'gene_id': gid, 'type': type_, 'accession': acc})
+        info = re.match(self.header_pattern, header).groupdict()
+        for key in ['TaxID', 'Tax', 'RepID', 'n']:
+            if info[key] is None:
+                del info[key]
         _intify(info, ('n',))
         return info
 

--- a/tests/test_fasta.py
+++ b/tests/test_fasta.py
@@ -261,13 +261,13 @@ class ParserTest(unittest.TestCase):
         header = ('>UniRef100_A5DI11 Elongation factor 2 n=1 '
                 'Tax=Pichia guilliermondii RepID=EF2_PICGU')
         parsed = {'RepID': 'EF2_PICGU',
-                 'taxon': 'PICGU',
-                 'gene_id': 'EF2',
+                 # 'taxon': 'PICGU',
+                 # 'gene_id': 'EF2',
                  'Tax': 'Pichia guilliermondii',
                  'cluster': 'Elongation factor 2',
                  'id': 'UniRef100_A5DI11',
-                 'type': 'UniRef100',
-                 'accession': 'A5DI11',
+                 # 'type': 'UniRef100',
+                 # 'accession': 'A5DI11',
                  'n': 1}
         self.assertEqual(fasta.parse(header), parsed)
 


### PR DESCRIPTION
This PR changes the UniRef header parser in a way similar to what #93 did for Uniprot, only recognizing the keys described in the [UniProt specification](https://www.uniprot.org/help/fasta-headers) for UniRef.

In addition to changing the pattern, it removes extra keys and values that were produced by splitting the values of _UniqueIdentifier_ and _RepresentativeMember_ on `_`. The latter was resulting in errors on the Uniref database downloaded from uniprot.org, so apparently the parser wasn't getting much use, and the change won't affect anyone.

However, some alternatives can still be discussed, like providing extra keys only when splitting is successful. This would result in errors in user code when a key is suddenly missing, as opposed to these keys consistently absent in the output with the currently proposed change.