### PR TITLE
Pass through the decode_binary parameter in read for mzml and mzxml

### DIFF
--- a/pyteomics/mzml.py
+++ b/pyteomics/mzml.py
@@ -357,7 +357,7 @@ class MzML(xml.ArrayConversionMixin, aux.TimeOrderedIndexedReaderMixin, xml.Mult
         return scan['scanList']['scan'][0]['scan start time']
 
 
-def read(source, read_schema=False, iterative=True, use_index=False, dtype=None, huge_tree=False):
+def read(source, read_schema=False, iterative=True, use_index=False, dtype=None, huge_tree=False, decode_binary=True):
     """Parse `source` and iterate through spectra.
 
     Parameters
@@ -403,7 +403,8 @@ def read(source, read_schema=False, iterative=True, use_index=False, dtype=None,
     """
 
     return MzML(source, read_schema=read_schema, iterative=iterative,
-        use_index=use_index, dtype=dtype, huge_tree=huge_tree)
+                use_index=use_index, dtype=dtype, huge_tree=huge_tree,
+                decode_binary=decode_binary)
 
 def iterfind(source, path, **kwargs):
     """Parse `source` and yield info on elements with specified local

--- a/pyteomics/mzxml.py
+++ b/pyteomics/mzxml.py
@@ -223,7 +223,8 @@ class MzXML(xml.ArrayConversionMixin, aux.TimeOrderedIndexedReaderMixin, xml.Mul
         return scan['retentionTime']
 
 
-def read(source, read_schema=False, iterative=True, use_index=False, dtype=None, huge_tree=False):
+def read(source, read_schema=False, iterative=True, use_index=False, dtype=None,
+         huge_tree=False, decode_binary=True):
     """Parse `source` and iterate through spectra.
 
     Parameters
@@ -265,7 +266,8 @@ def read(source, read_schema=False, iterative=True, use_index=False, dtype=None,
     """
 
     return MzXML(source, read_schema=read_schema, iterative=iterative,
-        use_index=use_index, dtype=dtype, huge_tree=huge_tree)
+                 use_index=use_index, dtype=dtype, huge_tree=huge_tree,
+                 decode_binary=decode_binary)
 
 
 def iterfind(source, path, **kwargs):


### PR DESCRIPTION
Fixes #104

Similar problem found for `mzxml` which is fixed as well. `mzmlb` does not this option in its `read` function.
