### PR TITLE
Fix iteration in example for calculating theoretical fragment m/z

### DIFF
--- a/doc/source/_static/example_msms.py
+++ b/doc/source/_static/example_msms.py
@@ -31,7 +31,7 @@ def fragments(peptide, types=('b', 'y'), maxcharge=1):
     The function generates all possible m/z for fragments of types
     `types` and of charges from 1 to `maxharge`.
     """
-    for i in range(1, len(peptide)-1):
+    for i in range(1, len(peptide)):
         for ion_type in types:
             for charge in range(1, maxcharge+1):
                 if ion_type[0] in 'abc':


### PR DESCRIPTION
https://github.com/levitsky/pyteomics/blob/5661fd40512884113adf6699388cbf69d4a93c02/doc/source/_static/example_msms.py#L34

If I am not mistaken this loop should go from inclusive 1 to inclusive len(peptide) - 1 to generate all fragment masses. Since the upper bound of range is exclusive we don't need to substract the 1 here.

The previous code would miss one ion of each ion type.
E.g.
For b ions PEPT would give P, PE and missing PEP since "PEPT"[:2] = "PE" where 2 is the maximum of iterable i
Similarly for y ions it would give EPT, PT and missing T since "PEPT"[2:] = "PT"
