### PR TITLE
Add raw fasta file header to parsers

### DIFF
--- a/pyteomics/fasta.py
+++ b/pyteomics/fasta.py
@@ -117,11 +117,12 @@ from . import auxiliary as aux
 
 Protein = namedtuple('Protein', ('description', 'sequence'))
 DECOY_PREFIX = 'DECOY_'
+RAW_HEADER_KEY = '__raw__'
 
 
 def _add_raw_field(parser):
     """
-    Add "_raw" field to the parsed dictinary
+    Add :py:const:`RAW_HEADER_KEY` field to the parsed dictinary.
 
     Parameters
     ----------
@@ -133,13 +134,13 @@ def _add_raw_field(parser):
     None.
 
     """
-    def _new_parser(cls, descr):
-        parsed = parser(cls, descr)
-        if not '_raw' in parsed.keys():
-            parsed['_raw'] = descr
+    def _new_parser(instance, descr):
+        parsed = parser(instance, descr)
+        if not RAW_HEADER_KEY in parsed:
+            parsed[RAW_HEADER_KEY] = descr
         else:
-            raise aux.PytemicsError('Cannot save raw protein header, since the corresponsing\
-                                    key (_raw) already exists')
+            raise aux.PytemicsError('Cannot save raw protein header, since the corresponsing'
+                                    'key ({}) already exists.'.format(RAW_HEADER_KEY))
         return parsed
 
     return _new_parser
@@ -655,8 +656,8 @@ def write(entries, output=None):
     ----------
     entries : iterable of (str/dict, str) tuples
         An iterable of 2-tuples in the form (description, sequence).
-        If description is a dictionary, it should contain a key "_raw"
-        that will be used for protein description.
+        If description is a dictionary, the value for :py:const:`RAW_HEADER_KEY`
+        will be written as protein description.
     output : file-like or str, optional
         A file open for writing or a path to write to. If the file exists,
         it will be opened for writing. Default is :py:const:`None`, which
@@ -679,10 +680,10 @@ def write(entries, output=None):
         The file where the FASTA is written.
     """
     for descr, seq in entries:
-        if type(descr) is str:
+        if isinstance(descr, str):
             output.write('>' + descr.replace('\n', '\n;') + '\n')
-        elif type(descr) is dict and '_raw' in descr.keys():
-            output.write('>' + descr['_raw'].replace('\n', '\n;') + '\n')
+        elif isinstance(descr, dict) and RAW_HEADER_KEY in descr:
+            output.write('>' + descr[RAW_HEADER_KEY].replace('\n', '\n;') + '\n')
         else:
              raise aux.PyteomicsError('Cannot use provided description: ' + repr(descr))
         output.write(''.join([('%s\n' % seq[i:i+70])

--- a/tests/test_fasta.py
+++ b/tests/test_fasta.py
@@ -191,7 +191,7 @@ class ParserTest(unittest.TestCase):
                  'gene_id': 'ACOX',
                  'name': 'Acetoin catabolism protein X',
                  'taxon': 'RALEH',
-                 '_raw': header[0]}
+                 '_raw': 'PREFIX_' + header}
         self.assertEqual(entries[0][0], parsed)
         self.assertEqual(entries[0][1], 'SEQUENCE'[::-1])
         self.assertEqual(len(entries), 1)
@@ -211,7 +211,7 @@ class ParserTest(unittest.TestCase):
                  'gene_id': 'ACOX',
                  'name': 'Acetoin catabolism protein X',
                  'taxon': 'RALEH',
-                 '_raw': header[0]}
+                 '_raw': header}
         self.assertEqual(fasta.parse(header), parsed)
 
     def test_parser_uniprotkb_isoform(self):
@@ -274,7 +274,7 @@ class ParserTest(unittest.TestCase):
                  # 'type': 'UniRef100',
                  # 'accession': 'A5DI11',
                  'n': 1,
-                 '_raw': header[0][1:]}
+                 '_raw': header[1:]}
         self.assertEqual(fasta.parse(header), parsed)
 
     def test_parser_uniparc(self):
@@ -292,7 +292,7 @@ class ParserTest(unittest.TestCase):
                  'SV': 1,
                  'id': 'MES00000000005',
                  'name': 'Putative uncharacterized protein GOS_3018412 (Fragment)',
-                 '_raw': header[0]}
+                 '_raw': header}
         self.assertEqual(fasta.parse(header), parsed)
 
     def test_parser_spd(self):
@@ -304,7 +304,7 @@ class ParserTest(unittest.TestCase):
                  'gene_id': '1433S',
                  'id': 'P31947',
                  'taxon': 'HUMAN',
-                 '_raw': header[0][1:]}
+                 '_raw': header[1:]}
         self.assertEqual(fasta.parse(header), parsed)
 
     def test_parser_spd_mult_ids(self):
@@ -316,7 +316,7 @@ class ParserTest(unittest.TestCase):
                  'gene_id': 'A1AG1',
                  'id': 'P02763 Q8TC16',
                  'taxon': 'HUMAN',
-                 '_raw': header[0][1:]}
+                 '_raw': header[1:]}
         self.assertEqual(fasta.parse(header), parsed)
 
     def test_parser_ncbi(self):

--- a/tests/test_fasta.py
+++ b/tests/test_fasta.py
@@ -227,7 +227,7 @@ class ParserTest(unittest.TestCase):
                  fasta.RAW_HEADER_KEY: header}
         self.assertEqual(fasta.parse(header), parsed)
 
-    def test_parser_unitprot_equals(self):
+    def test_parser_uniprot_equals(self):
         header = 'tr|Q9S8M8|Q9S8M8_WHEAT FRIII-2-VIII=GAMMA-gliadin (Fragment) OS=Triticum aestivum OX=4565 PE=1 SV=1'
         parsed = {
             'db': 'tr',

--- a/tests/test_fasta.py
+++ b/tests/test_fasta.py
@@ -190,7 +190,8 @@ class ParserTest(unittest.TestCase):
                  'id': 'P27748',
                  'gene_id': 'ACOX',
                  'name': 'Acetoin catabolism protein X',
-                 'taxon': 'RALEH'}
+                 'taxon': 'RALEH',
+                 '_raw': header[0]}
         self.assertEqual(entries[0][0], parsed)
         self.assertEqual(entries[0][1], 'SEQUENCE'[::-1])
         self.assertEqual(len(entries), 1)
@@ -209,7 +210,8 @@ class ParserTest(unittest.TestCase):
                  'id': 'P27748',
                  'gene_id': 'ACOX',
                  'name': 'Acetoin catabolism protein X',
-                 'taxon': 'RALEH'}
+                 'taxon': 'RALEH',
+                 '_raw': header[0]}
         self.assertEqual(fasta.parse(header), parsed)
 
     def test_parser_uniprotkb_isoform(self):
@@ -221,7 +223,8 @@ class ParserTest(unittest.TestCase):
                  'gene_id': '1433B',
                  'id': 'Q4R572-2',
                  'name': 'Isoform Short of 14-3-3 protein beta/alpha',
-                 'taxon': 'MACFA'}
+                 'taxon': 'MACFA',
+                 '_raw': header}
         self.assertEqual(fasta.parse(header), parsed)
 
     def test_parser_unitprot_equals(self):
@@ -236,7 +239,8 @@ class ParserTest(unittest.TestCase):
             'OS': 'Triticum aestivum',
             'OX': 4565,
             'PE': 1,
-            'SV': 1
+            'SV': 1,
+            '_raw': header
         }
         self.assertEqual(fasta.parse(header), parsed)
 
@@ -253,7 +257,8 @@ class ParserTest(unittest.TestCase):
             'OX': 4565,
             'GN': 'GluD3-3',
             'PE': 4,
-            'SV': 1
+            'SV': 1,
+            '_raw': header
         }
         self.assertEqual(fasta.parse(header), parsed)
 
@@ -268,12 +273,15 @@ class ParserTest(unittest.TestCase):
                  'id': 'UniRef100_A5DI11',
                  # 'type': 'UniRef100',
                  # 'accession': 'A5DI11',
-                 'n': 1}
+                 'n': 1,
+                 '_raw': header[0][1:]}
         self.assertEqual(fasta.parse(header), parsed)
 
     def test_parser_uniparc(self):
         header = '>UPI0000000005 status=active'
-        parsed = {'id': 'UPI0000000005', 'status': 'active'}
+        parsed = {'id': 'UPI0000000005',
+                  'status': 'active',
+                  '_raw': header[1:]}
         self.assertEqual(fasta.parse(header), parsed)
 
     def test_parser_unimes(self):
@@ -283,7 +291,8 @@ class ParserTest(unittest.TestCase):
                  'Pep': 'JCVI_PEP_1096688850003',
                  'SV': 1,
                  'id': 'MES00000000005',
-                 'name': 'Putative uncharacterized protein GOS_3018412 (Fragment)'}
+                 'name': 'Putative uncharacterized protein GOS_3018412 (Fragment)',
+                 '_raw': header[0]}
         self.assertEqual(fasta.parse(header), parsed)
 
     def test_parser_spd(self):
@@ -294,7 +303,8 @@ class ParserTest(unittest.TestCase):
                  'gene': '1433S_HUMAN',
                  'gene_id': '1433S',
                  'id': 'P31947',
-                 'taxon': 'HUMAN'}
+                 'taxon': 'HUMAN',
+                 '_raw': header[0][1:]}
         self.assertEqual(fasta.parse(header), parsed)
 
     def test_parser_spd_mult_ids(self):
@@ -305,14 +315,16 @@ class ParserTest(unittest.TestCase):
                  'gene': 'A1AG1_HUMAN',
                  'gene_id': 'A1AG1',
                  'id': 'P02763 Q8TC16',
-                 'taxon': 'HUMAN'}
+                 'taxon': 'HUMAN',
+                 '_raw': header[0][1:]}
         self.assertEqual(fasta.parse(header), parsed)
 
     def test_parser_ncbi(self):
         header = '>NP_001351877.1 acylglycerol kinase, mitochondrial isoform 2 [Homo sapiens]'
         parsed = {'description': 'acylglycerol kinase, mitochondrial isoform 2',
                  'id': 'NP_001351877.1',
-                 'taxon': 'Homo sapiens'}
+                 'taxon': 'Homo sapiens',
+                 '_raw': header[1:]}
         self.assertEqual(fasta.parse(header), parsed)
 
 

--- a/tests/test_fasta.py
+++ b/tests/test_fasta.py
@@ -214,6 +214,28 @@ class ParserTest(unittest.TestCase):
                  fasta.RAW_HEADER_KEY: header}
         self.assertEqual(fasta.parse(header), parsed)
 
+    def test_parser_uniprotkb_write(self):
+        header = ('sp|P27748|ACOX_RALEH Acetoin catabolism protein X OS=Ralstonia'
+            ' eutropha (strain ATCC 17699 / H16 / DSM 428 / Stanier 337)'
+            ' GN=acoX PE=4 SV=2')
+        parsed = {'GN': 'acoX',
+                 'OS': 'Ralstonia eutropha '
+                    '(strain ATCC 17699 / H16 / DSM 428 / Stanier 337)',
+                 'PE': 4,
+                 'SV': 2,
+                 'db': 'sp',
+                 'entry': 'ACOX_RALEH',
+                 'id': 'P27748',
+                 'gene_id': 'ACOX',
+                 'name': 'Acetoin catabolism protein X',
+                 'taxon': 'RALEH',
+                 fasta.RAW_HEADER_KEY: header}
+        with tempfile.TemporaryFile(mode='r+') as new_fasta_file:
+            fasta.write([(parsed, 'SEQUENCE')], new_fasta_file)
+            new_fasta_file.seek(0)
+            new_entries = list(fasta.read(new_fasta_file))
+            self.assertEqual([(header, 'SEQUENCE')], new_entries)
+
     def test_parser_uniprotkb_isoform(self):
         header = 'sp|Q4R572-2|1433B_MACFA Isoform Short of 14-3-3 protein beta/alpha OS=Macaca fascicularis GN=YWHAB'
         parsed = {'GN': 'YWHAB',

--- a/tests/test_fasta.py
+++ b/tests/test_fasta.py
@@ -191,7 +191,7 @@ class ParserTest(unittest.TestCase):
                  'gene_id': 'ACOX',
                  'name': 'Acetoin catabolism protein X',
                  'taxon': 'RALEH',
-                 '_raw': 'PREFIX_' + header}
+                 fasta.RAW_HEADER_KEY: 'PREFIX_' + header}
         self.assertEqual(entries[0][0], parsed)
         self.assertEqual(entries[0][1], 'SEQUENCE'[::-1])
         self.assertEqual(len(entries), 1)
@@ -211,7 +211,7 @@ class ParserTest(unittest.TestCase):
                  'gene_id': 'ACOX',
                  'name': 'Acetoin catabolism protein X',
                  'taxon': 'RALEH',
-                 '_raw': header}
+                 fasta.RAW_HEADER_KEY: header}
         self.assertEqual(fasta.parse(header), parsed)
 
     def test_parser_uniprotkb_isoform(self):
@@ -224,7 +224,7 @@ class ParserTest(unittest.TestCase):
                  'id': 'Q4R572-2',
                  'name': 'Isoform Short of 14-3-3 protein beta/alpha',
                  'taxon': 'MACFA',
-                 '_raw': header}
+                 fasta.RAW_HEADER_KEY: header}
         self.assertEqual(fasta.parse(header), parsed)
 
     def test_parser_unitprot_equals(self):
@@ -240,7 +240,7 @@ class ParserTest(unittest.TestCase):
             'OX': 4565,
             'PE': 1,
             'SV': 1,
-            '_raw': header
+            fasta.RAW_HEADER_KEY: header
         }
         self.assertEqual(fasta.parse(header), parsed)
 
@@ -258,7 +258,7 @@ class ParserTest(unittest.TestCase):
             'GN': 'GluD3-3',
             'PE': 4,
             'SV': 1,
-            '_raw': header
+            fasta.RAW_HEADER_KEY: header
         }
         self.assertEqual(fasta.parse(header), parsed)
 
@@ -274,14 +274,14 @@ class ParserTest(unittest.TestCase):
                  # 'type': 'UniRef100',
                  # 'accession': 'A5DI11',
                  'n': 1,
-                 '_raw': header[1:]}
+                 fasta.RAW_HEADER_KEY: header[1:]}
         self.assertEqual(fasta.parse(header), parsed)
 
     def test_parser_uniparc(self):
         header = '>UPI0000000005 status=active'
         parsed = {'id': 'UPI0000000005',
                   'status': 'active',
-                  '_raw': header[1:]}
+                  fasta.RAW_HEADER_KEY: header[1:]}
         self.assertEqual(fasta.parse(header), parsed)
 
     def test_parser_unimes(self):
@@ -292,7 +292,7 @@ class ParserTest(unittest.TestCase):
                  'SV': 1,
                  'id': 'MES00000000005',
                  'name': 'Putative uncharacterized protein GOS_3018412 (Fragment)',
-                 '_raw': header}
+                 fasta.RAW_HEADER_KEY: header}
         self.assertEqual(fasta.parse(header), parsed)
 
     def test_parser_spd(self):
@@ -304,7 +304,7 @@ class ParserTest(unittest.TestCase):
                  'gene_id': '1433S',
                  'id': 'P31947',
                  'taxon': 'HUMAN',
-                 '_raw': header[1:]}
+                 fasta.RAW_HEADER_KEY: header[1:]}
         self.assertEqual(fasta.parse(header), parsed)
 
     def test_parser_spd_mult_ids(self):
@@ -316,7 +316,7 @@ class ParserTest(unittest.TestCase):
                  'gene_id': 'A1AG1',
                  'id': 'P02763 Q8TC16',
                  'taxon': 'HUMAN',
-                 '_raw': header[1:]}
+                 fasta.RAW_HEADER_KEY: header[1:]}
         self.assertEqual(fasta.parse(header), parsed)
 
     def test_parser_ncbi(self):
@@ -324,7 +324,7 @@ class ParserTest(unittest.TestCase):
         parsed = {'description': 'acylglycerol kinase, mitochondrial isoform 2',
                  'id': 'NP_001351877.1',
                  'taxon': 'Homo sapiens',
-                 '_raw': header[1:]}
+                 fasta.RAW_HEADER_KEY: header[1:]}
         self.assertEqual(fasta.parse(header), parsed)
 
 


### PR DESCRIPTION
This PR adds an entry to FASTA file parsers that contains raw (i.e. non-parsed header). The latter is used by the `write` to write parsed protein entries.

Useful, for the fast filtering of FASTA files, for example:
```
from pyteomics import fasta
fasta_entries = fasta.UniProt('uniprot_multi_organism.fasta')
fasta.write([protein for protein in fasta_entries if protein.description.get('OX', -1) == 123], 'uniprot_single_organism.fasta')
```