### PR TITLE
Update imports for sqlalchemy v2.0 changes

### DIFF
--- a/pyteomics/mass/unimod.py
+++ b/pyteomics/mass/unimod.py
@@ -28,7 +28,10 @@ This module requires :py:mod:`lxml` and :py:mod:`sqlalchemy`.
 import re
 
 from lxml import etree
-from sqlalchemy.ext.declarative import declarative_base, DeclarativeMeta
+try:
+    from sqlalchemy.orm import declarative_base, DeclarativeMeta
+except ImportError:  # Moved in sqlalchemy 2.0
+    from sqlalchemy.ext.declarative import declarative_base, DeclarativeMeta
 from sqlalchemy.orm import relationship, backref, object_session
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy import (Numeric, Unicode,


### PR DESCRIPTION
In sqlalchemy version 2.0, `declarative_base` and `DeclarativeMeta` moved to another module. This adds a try-except around the imports to retain compatibility with sqlalchemy <2.0 and >2.0. Before, the import still worked, but resulted in `MovedIn20Warning` (for example: https://github.com/compomics/psm_utils/actions/runs/6239222484/job/16936699966?pr=50#step:7:35)