### PR TITLE
If psims is available, use its Unimod because it caches and vendors

### DIFF
--- a/pyteomics/proforma.py
+++ b/pyteomics/proforma.py
@@ -361,7 +361,7 @@ class UnimodResolver(ModificationResolver):
 
     def load_database(self):
         if _has_psims:
-            return load_unimod()
+            return obo_cache.load("http://www.unimod.org/obo/unimod.obo")
         return Unimod()
 
     def resolve(self, name=None, id=None, **kwargs):
@@ -397,9 +397,12 @@ class UnimodResolver(ModificationResolver):
                 'provider': self.name
             }
         else:
+            name = defn.ex_code_name
+            if not name:
+                name = defn.code_name
             return {
                 "composition": defn.composition,
-                "name": defn.ex_code_name,
+                "name": name,
                 "id": defn.id,
                 "mass": defn.monoisotopic_mass,
                 "provider": self.name

--- a/pyteomics/proforma.py
+++ b/pyteomics/proforma.py
@@ -32,7 +32,8 @@ except ImportError:
     np = None
 
 try:
-    from psims.controlled_vocabulary.controlled_vocabulary import (load_psimod, load_xlmod, load_gno, obo_cache)
+    from psims.controlled_vocabulary.controlled_vocabulary import (load_psimod, load_xlmod, load_gno, obo_cache, load_unimod)
+    _has_psims = True
 except ImportError:
     def _needs_psims(name):
         raise ImportError("Loading %s requires the `psims` library. To access it, please install `psims`" % name)
@@ -40,7 +41,9 @@ except ImportError:
     load_psimod = partial(_needs_psims, 'PSIMOD')
     load_xlmod = partial(_needs_psims, 'XLMOD')
     load_gno = partial(_needs_psims, 'GNO')
+    load_unimod = partial(_needs_psims, 'UNIMOD')
     obo_cache = None
+    _has_psims = False
 
 _water_mass = calculate_mass("H2O")
 
@@ -357,6 +360,8 @@ class UnimodResolver(ModificationResolver):
         self.strict = kwargs.get("strict", True)
 
     def load_database(self):
+        if _has_psims:
+            return load_unimod()
         return Unimod()
 
     def resolve(self, name=None, id=None, **kwargs):

--- a/pyteomics/proforma.py
+++ b/pyteomics/proforma.py
@@ -361,7 +361,7 @@ class UnimodResolver(ModificationResolver):
 
     def load_database(self):
         if _has_psims:
-            return obo_cache.load("http://www.unimod.org/obo/unimod.obo")
+            return obo_cache.resolve("http://www.unimod.org/obo/unimod.obo")
         return Unimod()
 
     def resolve(self, name=None, id=None, **kwargs):


### PR DESCRIPTION
Fixes #128 

If available, `proforma` will use `psims`'s Unimod API instead. This way applications and users can use `psims`'s caching features and have access to a fallback copy of the supported controlled vocabularies when the internet is inaccessible.