### PR TITLE
Fix UniMod by ID

### DIFF
--- a/tests/test_mgf.py
+++ b/tests/test_mgf.py
@@ -153,9 +153,10 @@ class MGFTest(unittest.TestCase):
                 mgf.write(spectra=spectrum, output=tmpfile)
 
         self.assertGreaterEqual(len(ws), 2)
+        n_warned = 0
         for w in ws:
-            self.assertTrue(issubclass(w.category, UserWarning))
-            self.assertTrue("discouraged" in str(w.message))
+            n_warned += (issubclass(w.category, UserWarning) and "discouraged" in str(w.message))
+        self.assertGreaterEqual(n_warned, 2)
         tmpfile.seek(0)
         tmpreader = mgf.read(tmpfile)
         self.assertEqual(data.mgf_spectra_long, list(tmpreader))

--- a/tests/test_mgf.py
+++ b/tests/test_mgf.py
@@ -152,7 +152,7 @@ class MGFTest(unittest.TestCase):
             for spectrum in self.spectra:
                 mgf.write(spectra=spectrum, output=tmpfile)
 
-        self.assertEqual(len(ws), 2)
+        self.assertGreaterEqual(len(ws), 2)
         for w in ws:
             self.assertTrue(issubclass(w.category, UserWarning))
             self.assertTrue("discouraged" in str(w.message))


### PR DESCRIPTION
Fixes #132 

The `psims` implementation used one big dispatching resolver for all identifiers, and I forgot to include a `by_id` alias. `__getitem__` should work as intended both with and without `psims`. If this is a Py2 issue, it may be harder to patch.