### PR TITLE
Calculate m/z for proforma in calculate_mass

### DIFF
--- a/pyteomics/proforma.py
+++ b/pyteomics/proforma.py
@@ -45,7 +45,7 @@ except ImportError:
     obo_cache = None
     _has_psims = False
 
-_water_mass = calculate_mass("H2O")
+_WATER_MASS = calculate_mass(formula="H2O")
 
 std_aa_mass = std_aa_mass.copy()
 std_aa_mass['X'] = 0
@@ -554,7 +554,7 @@ class GNOResolver(ModificationResolver):
         if not match:
             return None
         # This will have a small mass error.
-        rough_mass = float(match.group(1)) - _water_mass
+        rough_mass = float(match.group(1)) - _WATER_MASS
         if raw_mass is not None and abs(rough_mass - raw_mass) < 1:
             return raw_mass
         warnings.warn(
@@ -2036,8 +2036,6 @@ class _ProFormaProperty(object):
         template = "{self.__class__.__name__}({self.name!r})"
         return template.format(self=self)
 
-
-_WATER_MASS = calculate_mass(formula="H2O")
 
 class ProForma(object):
     '''Represent a parsed ProForma sequence.

--- a/tests/test_mass.py
+++ b/tests/test_mass.py
@@ -188,6 +188,17 @@ class MassTest(unittest.TestCase):
                 mass.calculate_mass(parsed_sequence=parser.parse(pep, labels=['X', 'Y', 'Z'], show_unmodified_termini=True),
                     aa_comp=self.aa_comp, mass_data=self.mass_data, ion_comp=self.ion_comp))
 
+    def test_calculate_proforma_mass(self):
+        seq_modX = 'PEPTIcamCIDE'
+        aa_comp = mass.std_aa_comp.copy()
+        aa_comp['cam'] = mass.Composition(formula='H3C2NO')
+        seq_proforma = 'PEPTIC[+57.021464]IDE'
+        for charge in [None, 0, 1, 2]:
+            self.assertAlmostEqual(
+                mass.calculate_mass(sequence=seq_modX, charge=charge, aa_comp=aa_comp),
+                mass.calculate_mass(proforma=seq_proforma, charge=charge),
+                places=6)
+
     def test_most_probable_isotopic_composition(self):
         self.assertEqual(
             mass.most_probable_isotopic_composition(formula='F', mass_data=self.mass_data),


### PR DESCRIPTION
This PR adds a new optional argument to `mass.calculate_mass`, `proforma`. If specified, it should be a ProForma string or a `proforma.ProForma` object. Its `mass` property is then converted to m/z if needed.