### PR TITLE
Rename _build_index to build_byte_index

### DIFF
--- a/pyteomics/auxiliary/file_helpers.py
+++ b/pyteomics/auxiliary/file_helpers.py
@@ -535,25 +535,24 @@ class IndexSavingMixin(NoOpBaseReader):
             self._offset_index.save(f)
 
     @_keepstate_method
-    def _build_index(self):
+    def build_byte_index(self):
         """Build the byte offset index by either reading these offsets
         from the file at :attr:`_byte_offset_filename`, or falling back
-        to the method used by :class:`IndexedXML` if this operation fails
+        to the method used by :class:`IndexedXML` or :class:`IndexedTextReader` if this operation fails
         due to an IOError
         """
-        if not self._use_index: return
+        if not getattr(self, '_use_index', True): return  # indexed text readers do not have `_use_index`
         try:
-            self._read_byte_offsets()
+            return self._read_byte_offsets()
         except (IOError, AttributeError, TypeError):
-            super(IndexSavingMixin, self)._build_index()
+            return super(IndexSavingMixin, self).build_byte_index()
 
     def _read_byte_offsets(self):
         """Read the byte offset index JSON file at :attr:`_byte_offset_filename`
         and populate :attr:`_offset_index`
         """
         with open(self._byte_offset_filename, 'r') as f:
-            index = self._index_class.load(f)
-            self._offset_index = index
+            return self._index_class.load(f)
 
 
 def _file_reader(_mode='r'):

--- a/pyteomics/mzml.py
+++ b/pyteomics/mzml.py
@@ -471,17 +471,22 @@ class PreIndexedMzML(MzML):
     """Parser class for mzML files, subclass of :py:class:`MzML`.
     Uses byte offsets listed at the end of the file for quick access to spectrum elements.
     """
-    def _build_index(self):
+    def build_byte_index(self):
         """
-        Build up a `dict` of `dict` of offsets for elements. Calls :meth:`_find_index_list`
-        and assigns the return value to :attr:`_offset_index`
+        Build up a :class:`HierarchicalOffsetIndex` of offsets for elements. Calls :meth:`_find_index_list` or
+        falls back on regular :class:`MzML` indexing.
+
+        Returns
+        -------
+
+        out : HierarchicalOffsetIndex
         """
         index = self._find_index_list()
         if index:
-            self._offset_index = index
+            return index
         else:
             warnings.warn('Could not extract the embedded offset index. Falling back to default indexing procedure.')
-            super(PreIndexedMzML, self)._build_index()
+            return super(PreIndexedMzML, self).build_byte_index()
 
     @xml._keepstate
     def _iterparse_index_list(self, offset):

--- a/pyteomics/mzmlb.py
+++ b/pyteomics/mzmlb.py
@@ -433,7 +433,7 @@ class MzMLb(TimeOrderedIndexedReaderMixin, TaskMappingMixin):
         self._mzml_parser = ExternalDataMzML(
             self._xml_buffer, external_data_registry=self._array_registry,
             use_index=False, **kwargs)
-        self._mzml_parser._offset_index = self._build_index()
+        self._mzml_parser._offset_index = self.build_byte_index()
         self._mzml_parser._use_index = True
 
     @property
@@ -442,7 +442,7 @@ class MzMLb(TimeOrderedIndexedReaderMixin, TaskMappingMixin):
             return self.path.name
         return self.path
 
-    def _build_index(self):
+    def build_byte_index(self):
         index = HierarchicalOffsetIndex()
         for label in [u'spectrum', u'chromatogram']:
             sub = index[label]

--- a/pyteomics/xml.py
+++ b/pyteomics/xml.py
@@ -1180,6 +1180,10 @@ class IndexedXML(IndexedReaderMixin, XML):
             return IndexedIterfind(self, path, **kwargs)
         return Iterfind(self, path, **kwargs)
 
+    def __init_subclass__(cls, **kwargs):  # only works on Python 3.x
+        super(IndexedXML, cls).__init_subclass__(**kwargs)
+        if hasattr(cls, '_build_index'):
+            warnings.warn("The method `_build_index` has been renamed to `build_byte_index`.")
 
 class MultiProcessingXML(IndexedXML, TaskMappingMixin):
     """XML reader that feeds indexes to external processes

--- a/tests/test_mgf.py
+++ b/tests/test_mgf.py
@@ -214,12 +214,15 @@ class MGFTest(unittest.TestCase):
             self.assertEqual(offsets_exist, inst._check_has_byte_offset_file())
             self.assertTrue(isinstance(inst._offset_index, aux.OffsetIndex))
         self.assertTrue(inst._source.closed)
-        mgf.IndexedMGF.prebuild_byte_offset_file(work_path)
+        with mgf.IndexedMGF(work_path) as inst:
+            inst._offset_index.pop('Spectrum 1')
+            inst.write_byte_offsets()
         with mgf.IndexedMGF(work_path) as inst:
             offsets_exist = os.path.exists(inst._byte_offset_filename)
             self.assertTrue(offsets_exist)
             self.assertEqual(offsets_exist, inst._check_has_byte_offset_file())
             self.assertTrue(isinstance(inst._offset_index, aux.OffsetIndex))
+            self.assertEqual(len(inst), 1)
         self.assertTrue(inst._source.closed)
         os.remove(inst._byte_offset_filename)
         with mgf.IndexedMGF(work_path) as inst:


### PR DESCRIPTION
Fixes #140.

- unified method name is now `build_byte_index` across all indexed and index-saving parsers;
- the method returns the index rather than assign it (the behavior of `build_byte_index` is preserved);
- warning is thrown when defining an `IndexedXML` subclass with a `_build_index` method (Python 3 only).

@mobiusklein could you please take a look at it?