### PR TITLE
Improve and document modX terminal group support

### DIFF
--- a/doc/source/mass.rst
+++ b/doc/source/mass.rst
@@ -152,8 +152,7 @@ modification on a specific residue:
 
 `Unimod database <http://www.unimod.org>`_ is an excellent resource for the
 information on the chemical compositions of known protein modifications.
-Version 2.0.3 introduces :py:class:`pyteomics.mass.Unimod` class that can serve
-as a Python interface to Unimod:
+:py:class:`pyteomics.mass.Unimod` class is a simple Python interface to Unimod:
 
 .. code-block:: python
 
@@ -188,6 +187,23 @@ as a Python interface to Unimod:
         >>> aa_comp['Ac-'] = aa_comp['ac'] + {'H': 1}  # adding the hydrogen produces a full acetyl group composition
         >>> mass.calculate_mass('Ac-PEPacTIDE-OH', aa_comp=aa_comp)
         883.38109339411  # correct!
+
+    The following will produce the same result. **Pyteomics** recognizes that you are using a *mod* label instead
+    of a terminal group and adds a hydrogen implicitly:
+
+    .. code-block:: python
+
+        >>> aa_comp = dict(mass.std_aa_comp)
+        >>> aa_comp['ac'] = db.by_title('Acetyl')['composition']
+        >>> mass.calculate_mass('ac-PEPacTIDE-OH', aa_comp=aa_comp)
+        883.38109339411  # correct!
+
+    For completeness, note that you can actually specify terminal groups directly by their formula in the sequence:
+
+    .. code-block:: python
+
+        >>> mass.calculate_mass('CH3CO-PEPacTIDE-OH', aa_comp=aa_comp)
+        883.38109339411
 
 Faster mass calculations
 ------------------------

--- a/doc/source/mass.rst
+++ b/doc/source/mass.rst
@@ -27,6 +27,7 @@ In :py:mod:`pyteomics.mass` there are two ways to approach these problems.
 
   The values of :py:data:`pyteomics.mass.std_aa_comp` are
   :py:class:`pyteomics.mass.Composition` objects.
+  You can do basic arithmetics with :py:class:`Composition` objects: add, subtract and multiply by integers.
 
 * All functions that accept a **formula** keyword argument sum and
   subtract numbers following the same atom in the formula:

--- a/doc/source/mass.rst
+++ b/doc/source/mass.rst
@@ -188,17 +188,7 @@ information on the chemical compositions of known protein modifications.
         >>> mass.calculate_mass('Ac-PEPacTIDE-OH', aa_comp=aa_comp)
         883.38109339411  # correct!
 
-    The following will produce the same result. **Pyteomics** recognizes that you are using a *mod* label instead
-    of a terminal group and adds a hydrogen implicitly:
-
-    .. code-block:: python
-
-        >>> aa_comp = dict(mass.std_aa_comp)
-        >>> aa_comp['ac'] = db.by_title('Acetyl')['composition']
-        >>> mass.calculate_mass('ac-PEPacTIDE-OH', aa_comp=aa_comp)
-        883.38109339411  # correct!
-
-    For completeness, note that you can actually specify terminal groups directly by their formula in the sequence:
+    For completeness, note that you can actually specify **terminal groups** directly by their formula in the sequence:
 
     .. code-block:: python
 

--- a/doc/source/parser.rst
+++ b/doc/source/parser.rst
@@ -7,7 +7,7 @@ modX
 **Pyteomics** uses a custom IUPAC-derived peptide sequence notation named **modX**.
 As in the IUPAC notation, each amino acid residue is represented by a capital
 letter, but it may preceded by an arbitrary number of small letters to show
-modification. Terminal modifications are separated from the backbone sequence by
+modification. Terminal groups are separated from the backbone sequence by
 a hyphen (‘-’). By default, both termini are assumed to be unmodified, which can be
 shown explicitly by 'H-' for N-terminal hydrogen and '-OH' for C-terminal hydroxyl.
 
@@ -23,7 +23,7 @@ Parsing
 
 There are two helper functions to check if a label is in modX format or represents
 a terminal modification: :py:func:`pyteomics.parser.is_modX` and
-:py:func:`pyteomics.parser.is_term_mod`:
+:py:func:`pyteomics.parser.is_term_group`:
 
 .. code-block:: python
 
@@ -33,9 +33,9 @@ a terminal modification: :py:func:`pyteomics.parser.is_modX` and
     True
     >>> parser.is_modX('pTx')
     False
-    >>> parser.is_term_mod('pT')
+    >>> parser.is_term_group('pT')
     False
-    >>> parser.is_term_mod('Ac-')
+    >>> parser.is_term_group('Ac-')
     True
 
 

--- a/pyteomics/parser.py
+++ b/pyteomics/parser.py
@@ -18,8 +18,8 @@ The valid examples of modX amino acid labels are: 'G', 'pS', 'oxM'. This rule
 allows to combine read- and parseability.
 
 Besides the sequence of amino acid residues, modX has a rule to specify
-terminal modifications of a polypeptide. Such a label should start or
-end with a hyphen. The default N-terminal amine group and C-terminal
+terminal modifications (alternative terminal groups) of a polypeptide.
+Such a label should start or end with a hyphen. The default N-terminal amine group and C-terminal
 carboxyl group may not be shown explicitly.
 
 Therefore, valid examples of peptide sequences in modX are: "GAGA",
@@ -62,8 +62,8 @@ Auxiliary commands
 
   :py:func:`is_modX` - check if supplied code corresponds to a modX label.
 
-  :py:func:`is_term_mod` - check if supplied code corresponds to a
-  terminal modification.
+  :py:func:`is_term_group` - check if supplied code corresponds to a
+  terminal group.
 
 Data
 ----
@@ -120,12 +120,12 @@ std_cterm = '-OH'
 std_labels = std_amino_acids + [std_nterm, std_cterm]
 """modX labels for the standard amino acids and unmodified termini."""
 
-_nterm_mod = r'[^-]+-$'
-_cterm_mod = r'-[^-]+$'
+_nterm_group = r'[^-]+-$'
+_cterm_group = r'-[^-]+$'
 
 
-def is_term_mod(label):
-    """Check if `label` corresponds to a terminal modification.
+def is_term_group(label):
+    """Check if `label` corresponds to a terminal group.
 
     Parameters
     ----------
@@ -137,18 +137,21 @@ def is_term_mod(label):
 
     Examples
     --------
-    >>> is_term_mod('A')
+    >>> is_term_group('A')
     False
-    >>> is_term_mod('Ac-')
+    >>> is_term_group('Ac-')
     True
-    >>> is_term_mod('-customGroup')
+    >>> is_term_group('-customGroup')
     True
-    >>> is_term_mod('this-group-')
+    >>> is_term_group('this-group-')
     False
-    >>> is_term_mod('-')
+    >>> is_term_group('-')
     False
     """
-    return (re.match(_nterm_mod, label) or re.match(_cterm_mod, label)) is not None
+    return (re.match(_nterm_group, label) or re.match(_cterm_group, label)) is not None
+
+
+is_term_group = is_term_group
 
 
 def match_modX(label):
@@ -222,13 +225,13 @@ def length(sequence, **kwargs):
         else:
             parsed_sequence = sequence
         num_term_groups = 0
-        if is_term_mod(parsed_sequence[0]):
+        if is_term_group(parsed_sequence[0]):
             num_term_groups += 1
-        if is_term_mod(parsed_sequence[-1]):
+        if is_term_group(parsed_sequence[-1]):
             num_term_groups += 1
         return len(parsed_sequence) - num_term_groups
     elif isinstance(sequence, dict):
-        return sum(amount for aa, amount in sequence.items() if not is_term_mod(aa))
+        return sum(amount for aa, amount in sequence.items() if not is_term_group(aa))
 
     raise PyteomicsError('Unsupported type of sequence.')
 
@@ -525,10 +528,10 @@ def to_proforma(sequence, **kwargs):
     nterm = cterm = None
     pro_sequence = []
     if isinstance(sequence[0], str):  # regular parsed sequence
-        if is_term_mod(sequence[0]) and sequence[0] != std_nterm:
+        if is_term_group(sequence[0]) and sequence[0] != std_nterm:
             nterm = get_tag(sequence[0])
             i = 1
-        if is_term_mod(sequence[-1]) and sequence[-1] != std_cterm:
+        if is_term_group(sequence[-1]) and sequence[-1] != std_cterm:
             cterm = get_tag(sequence[-1])
             j -= 1
         for label in sequence[i:j]:
@@ -538,9 +541,9 @@ def to_proforma(sequence, **kwargs):
                 mod, aa = _split_label(label)
                 pro_sequence.append((aa, get_tag(mod)))
     else:  # split sequence
-        if is_term_mod(sequence[0][0]) and sequence[0][0] != std_nterm:
+        if is_term_group(sequence[0][0]) and sequence[0][0] != std_nterm:
             nterm = get_tag(sequence[0][0])
-        if is_term_mod(sequence[-1][-1]) and sequence[-1][-1] != std_cterm:
+        if is_term_group(sequence[-1][-1]) and sequence[-1][-1] != std_cterm:
             cterm = get_tag(sequence[-1][-1])
         if len(sequence) == 1:
             pro_sequence = [(sequence[0][-2] if cterm else sequence[0][-1], get_tag(sequence[0][1]) if len(sequence[0]) == 4 else None)]
@@ -616,9 +619,9 @@ def amino_acid_composition(sequence, show_unmodified_termini=False, term_aa=Fals
 
     # Process terminal amino acids.
     if term_aa:
-        nterm_aa_position = 1 if is_term_mod(parsed_sequence[0]) else 0
+        nterm_aa_position = 1 if is_term_group(parsed_sequence[0]) else 0
         cterm_aa_position = (
-            len(parsed_sequence) - 2 if is_term_mod(parsed_sequence[-1])
+            len(parsed_sequence) - 2 if is_term_group(parsed_sequence[-1])
             else len(parsed_sequence) - 1)
         if len(parsed_sequence) > 1:
             aa_dict['cterm' + parsed_sequence.pop(cterm_aa_position)] = 1
@@ -984,13 +987,13 @@ def isoforms(sequence, **kwargs):
         group = list(label)
         m = main(group)[0]
         c = True  # whether the change is applied in the end
-        if m == 0 and not is_term_mod(mod):
+        if m == 0 and not is_term_group(mod):
             group.insert(0, mod)
         elif mod[0] == '-' and (group[-1] == std_cterm or (group[-1][0] == '-' and override)):
             group[-1] = mod
         elif mod[-1] == '-' and (group[0] == std_nterm or (group[0][-1] == '-' and override)):
             group[0] = mod
-        elif not is_term_mod(mod):
+        elif not is_term_group(mod):
             if m and group[m - 1][-1] != '-':
                 if override:
                     group[m - 1] = mod
@@ -1006,7 +1009,7 @@ def isoforms(sequence, **kwargs):
     variable_mods = kwargs.get('variable_mods', {})
     varmods_term, varmods_non_term = [], []
     for m, r in sorted(variable_mods.items()):
-        if is_term_mod(m):
+        if is_term_group(m):
             varmods_term.append((m, r))
         else:
             varmods_non_term.append((m, r))

--- a/pyteomics/parser.py
+++ b/pyteomics/parser.py
@@ -151,7 +151,7 @@ def is_term_group(label):
     return (re.match(_nterm_group, label) or re.match(_cterm_group, label)) is not None
 
 
-is_term_group = is_term_group
+is_term_mod = is_term_group
 
 
 def match_modX(label):

--- a/pyteomics/xml.py
+++ b/pyteomics/xml.py
@@ -722,7 +722,7 @@ def xpath(tree, path, ns=None):
         if not s: return 'd:'
         return '/d:'
     new_path = re.sub(r'(\/|^)(?![\*\/])', repl, path)
-    n_s = ({'d': ns} if ns else None)
+    n_s = {'d': ns} if ns else None
     return tree.xpath(new_path, namespaces=n_s)
 
 

--- a/tests/test_mass.py
+++ b/tests/test_mass.py
@@ -40,17 +40,17 @@ class MassTest(unittest.TestCase):
             for i in range(10)]
 
         self.aa_comp = {
-            'X':   mass.Composition({'A': 1}, mass_data=self.mass_data),
-            'Y':   mass.Composition({'B': 1}, mass_data=self.mass_data),
-            'Z':   mass.Composition({'C': 1}, mass_data=self.mass_data),
-            'F':   mass.Composition({'F': 1}, mass_data=self.mass_data),
-            'H-':  mass.Composition({'D': 1}, mass_data=self.mass_data),
-            '-OH': mass.Composition({'E': 1}, mass_data=self.mass_data),
+            'X':   mass.Composition({'A': 1}),
+            'Y':   mass.Composition({'B': 1}),
+            'Z':   mass.Composition({'C': 1}),
+            'F':   mass.Composition({'F': 1}),
+            'H-':  mass.Composition({'D': 1}),
+            '-OH': mass.Composition({'E': 1}),
         }
 
         self.ion_comp = {
-            'M': mass.Composition({}, mass_data=self.mass_data),
-            'a': mass.Composition({'A': -1}, mass_data=self.mass_data)
+            'M': mass.Composition({}),
+            'a': mass.Composition({'A': -1})
         }
 
         self.mods = {'a': mass.Composition(A=1), 'b': mass.Composition(B=1)}
@@ -78,6 +78,40 @@ class MassTest(unittest.TestCase):
                     self.mass_data['A'][0][0] + self.mass_data['B'][0][0] * 2 + self.mass_data['C'][0][0] * 3 +
                     self.mass_data['D'][0][0] + self.mass_data['E'][0][0] * 2 + self.mass_data['F'][0][0] * 3))
 
+    def test_fast_mass2_term_label(self):
+        mass_data = dict(self.mass_data)
+        mass_data['H'] = {0: (self.mass_H, 1.0)}
+        mass_data['O'] = {0: (self.mass_O, 1.0)}
+        aa_mass = self.test_aa_mass.copy()
+        aa_mass.update({k: mass.calculate_mass(composition=v, mass_data=mass_data) for k, v in self.mods.items()})
+        for pep in self.random_peptides:
+            for mlabel, mcomp in self.mods.items():
+                mpep = mlabel + '-' + pep + '-' + mlabel
+                self.assertAlmostEqual(
+                    mass.fast_mass2(mpep, mass_data=mass_data, aa_mass=aa_mass),
+                    mass.fast_mass2(pep, mass_data=mass_data, aa_mass=aa_mass)
+                        + 2 * mass.calculate_mass(composition=mcomp, mass_data=mass_data)
+                        - self.mass_O
+                    )
+
+    def test_composition_term(self):
+        aa_comp = self.aa_comp.copy()
+        aa_comp.update(self.mods)
+        for pep in self.random_peptides:
+            for mlabel, mcomp in self.mods.items():
+                mpep = mlabel + '-' + pep + '-' + mlabel
+                self.assertEqual(mass.Composition(sequence=mpep, aa_comp=aa_comp),
+                    mass.Composition(sequence=pep, aa_comp=aa_comp) - aa_comp['H-'] - aa_comp['-OH'] + mcomp * 2 + {'H': 2})
+
+    def test_composition_term_sseq(self):
+        aa_comp = self.aa_comp.copy()
+        aa_comp.update(self.mods)
+        for pep in self.random_peptides:
+            for mlabel, mcomp in self.mods.items():
+                split_sequence = parser.parse(pep, split=True)
+                self.assertEqual(mass.Composition(split_sequence=[
+                    (mlabel + '-',) + split_sequence[0]] + split_sequence[1:-1] + [split_sequence[-1] + ('-' + mlabel,)], aa_comp=aa_comp),
+                    mass.Composition(sequence=pep, aa_comp=aa_comp) - aa_comp['H-'] - aa_comp['-OH'] + mcomp * 2 + {'H': 2})
 
     def test_Composition_dict(self):
         # Test Composition from a dict.
@@ -102,6 +136,10 @@ class MassTest(unittest.TestCase):
         self.assertEqual(
             mass.Composition(split_sequence=[('X',), ('Y',), ('Z',)], aa_comp=self.aa_comp),
             {atom: 1 for atom in 'ABC'})
+
+    def test_Composition_term_formula(self):
+        self.assertEqual(mass.Composition(sequence='A2B-XYZ-DE2F3', aa_comp=self.aa_comp),
+            {'A': 3, 'B': 2, 'C': 1, 'D': 1, 'E': 2, 'F': 3})
 
     def test_Composition_sum(self):
         # Test sum of Composition objects.

--- a/tests/test_mass.py
+++ b/tests/test_mass.py
@@ -87,12 +87,8 @@ class MassTest(unittest.TestCase):
         for pep in self.random_peptides:
             for mlabel, mcomp in self.mods.items():
                 mpep = mlabel + '-' + pep + '-' + mlabel
-                self.assertAlmostEqual(
-                    mass.fast_mass2(mpep, mass_data=mass_data, aa_mass=aa_mass),
-                    mass.fast_mass2(pep, mass_data=mass_data, aa_mass=aa_mass)
-                        + 2 * mass.calculate_mass(composition=mcomp, mass_data=mass_data)
-                        - self.mass_O
-                    )
+                self.assertRaises(auxiliary.PyteomicsError,
+                    mass.fast_mass2, mpep, mass_data=mass_data, aa_mass=aa_mass)
 
     def test_composition_term(self):
         aa_comp = self.aa_comp.copy()
@@ -100,8 +96,7 @@ class MassTest(unittest.TestCase):
         for pep in self.random_peptides:
             for mlabel, mcomp in self.mods.items():
                 mpep = mlabel + '-' + pep + '-' + mlabel
-                self.assertEqual(mass.Composition(sequence=mpep, aa_comp=aa_comp),
-                    mass.Composition(sequence=pep, aa_comp=aa_comp) - aa_comp['H-'] - aa_comp['-OH'] + mcomp * 2 + {'H': 2})
+                self.assertRaises(auxiliary.PyteomicsError, mass.Composition, sequence=mpep, aa_comp=aa_comp)
 
     def test_composition_term_sseq(self):
         aa_comp = self.aa_comp.copy()
@@ -109,9 +104,8 @@ class MassTest(unittest.TestCase):
         for pep in self.random_peptides:
             for mlabel, mcomp in self.mods.items():
                 split_sequence = parser.parse(pep, split=True)
-                self.assertEqual(mass.Composition(split_sequence=[
-                    (mlabel + '-',) + split_sequence[0]] + split_sequence[1:-1] + [split_sequence[-1] + ('-' + mlabel,)], aa_comp=aa_comp),
-                    mass.Composition(sequence=pep, aa_comp=aa_comp) - aa_comp['H-'] - aa_comp['-OH'] + mcomp * 2 + {'H': 2})
+                self.assertRaises(auxiliary.PyteomicsError, mass.Composition, split_sequence=[
+                    (mlabel + '-',) + split_sequence[0]] + split_sequence[1:-1] + [split_sequence[-1] + ('-' + mlabel,)], aa_comp=aa_comp)
 
     def test_Composition_dict(self):
         # Test Composition from a dict.


### PR DESCRIPTION
This PR is in response to user feedback on the mailing list: https://groups.google.com/g/pyteomics/c/X__Vjy_d6r8

**The problem**
1. It is easy to add a modification to `aa_comp` from Unimod as a terminal modification, which produces incorrect compositions and masses, because terminal modifications should actually be specified by full group composition, while normal side-chain modifications are reduced by a hydrogen (as they represent a difference in compositions).
2. This potential error is not documented.

**The proposed solution** 
1. Expand documentation and warn the user.
2. Try to correct for this error: if a modification is specified with a *mod* label (not a term label), but used as a term label, a hydrogen is added automatically. Previously, this would just raise an exception because a term label would have to be present in `aa_comp`.
3. Also (not directly related) add direct support for specifying a terminal group by its formula. This worked for `fast_mass2`, but now also works for `Composition` and `calculate_mass`.

**Potential concerns**
Implicitly adding a hydrogen does not make sense for all modifications on Unimod (not all of them are even modifications). But then, it probably doesn't make sense to specify them as terminal, either.

Can we shoot ourselves in the foot by applying this implicit correction? 