### PR TITLE
Fix silencing of errors during ProForma mass calculations

### DIFF
--- a/tests/test_proforma.py
+++ b/tests/test_proforma.py
@@ -26,8 +26,7 @@ class ProFormaTest(unittest.TestCase):
         assert properties['fixed_modifications'][0] == ModificationRule(
             GenericModification('Carbamidomethyl', None, None), ['C'])
         assert to_proforma(tokens, **properties) == complicated_short
-        self.assertAlmostEqual(
-            ProForma(tokens, properties).mass, 1210.5088, 3)
+        self.assertAlmostEqual(ProForma(tokens, properties).mass, 1228.6588, 3)
 
     def test_range(self):
         seq = "PRQT(EQC[Carbamidomethyl]FQRMS)[+19.0523]ISK"


### PR DESCRIPTION
Closes #157 

This issue also masked an error in one of the unit tests, where an attribute was misspelled. Previously, I was silently ignoring errors because not all tags have a mass value. Instead, now each tag is asked if it is expected to have a mass value, and if so, it is accessed and added to the accumulator.

Since modifications load lazily, and then read the mass value out of a `dict`, the `KeyError` could either be the result of a lookup failure for a modification resolver, or a lookup failure for the resolved properties of the modification, which would silence both mass lookup issues and modification resolution issues. Both of these are now resolved.
