### PR TITLE
Ensure URL prefix when creating a mass.Unimod

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,3 +35,24 @@ jobs:
     - name: Run the tests
       run: |
         cd tests; find . -name 'test_*.py' -print0 | xargs -0 -n1 python
+
+  tests-multiplatform:
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        os: ['macos-latest', 'windows-latest']
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+      - name: Run the tests
+        run: |
+          cd tests; python -m unittest test_auxiliary.UtilTest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -55,4 +55,4 @@ jobs:
           pip install .
       - name: Run the tests
         run: |
-          cd tests; python -m unittest test_auxiliary.UtilTest
+          cd tests; python -m unittest test_util.UtilTest

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 -----
 
  - **Drop Python 2 support.** See `#167 <https://github.com/levitsky/pyteomics/discussions/167>`_ for the announcement.
+ - Ensure URL prefix when creating a :py:class:`mass.Unimod` object (`#169 <https://github.com/levitsky/pyteomics/pull/169>`_).
  - Improve :py:mod:`spectrum_utils` integration.
  - Retain StPeter output in :py:func:`pyteomics.protxml.DataFrame`.
  - Fix `#163 <https://github.com/levitsky/pyteomics/issues/163>`_

--- a/pyteomics/auxiliary/__init__.py
+++ b/pyteomics/auxiliary/__init__.py
@@ -27,4 +27,4 @@ from .target_decoy import (
 
 from .utils import (
     print_tree, memoize, BinaryDataArrayTransformer, ArrayConversionMixin, BinaryArrayConversionMixin,
-    MaskedArrayConversionMixin, _decode_base64_data_array)
+    MaskedArrayConversionMixin, _decode_base64_data_array, ensure_url_prefix)

--- a/pyteomics/mass/mass.py
+++ b/pyteomics/mass/mass.py
@@ -82,7 +82,7 @@ Data
 
 import math
 from .. import parser
-from ..auxiliary import PyteomicsError, _nist_mass, BasicComposition
+from ..auxiliary import PyteomicsError, _nist_mass, BasicComposition, ensure_url_prefix
 from itertools import chain, product, combinations_with_replacement
 from collections import defaultdict
 try:
@@ -93,6 +93,7 @@ from datetime import datetime
 import re
 import operator
 import warnings
+from pathlib import Path
 
 nist_mass = _nist_mass
 """
@@ -1049,6 +1050,9 @@ def fast_mass2(sequence, ion_type=None, charge=None, **kwargs):
     return mass
 
 
+UNIMOD_DEFAULT_URL = 'http://www.unimod.org/xml/unimod.xml'
+
+
 class Unimod():
     """A class for Unimod database of modifications.
     The list of all modifications can be retrieved via `mods` attribute.
@@ -1060,15 +1064,14 @@ class Unimod():
         more features.
     """
 
-    def __init__(self, source='http://www.unimod.org/xml/unimod.xml'):
+    def __init__(self, source=UNIMOD_DEFAULT_URL):
         """Create a database and fill it from XML file retrieved from `source`.
 
         Parameters
         ----------
 
-        source : str or file, optional
-            A file-like object or a URL to read from. Don't forget the ``'file://'``
-            prefix when pointing to local files.
+        source : str or Path or file, optional
+            A file-like object, file name or a URL to read from.
         """
         from lxml import etree
         from ..xml import _local_name
@@ -1130,8 +1133,9 @@ class Unimod():
             new_d['refs'] = refs
             return new_d
 
-        if isinstance(source, str):
-            self._tree = etree.parse(urlopen(source))
+        if isinstance(source, (str, Path)):
+            url = ensure_url_prefix(source)
+            self._tree = etree.parse(urlopen(url))
         else:
             self._tree = etree.parse(source)
         self._massdata = self._mass_data()

--- a/tests/test_auxiliary.py
+++ b/tests/test_auxiliary.py
@@ -997,7 +997,7 @@ class UtilTest(unittest.TestCase):
             pairs.extend(pairs_other)
         for inp, out in pairs:
             try:
-                self.assertEqual(aux.ensure_prefix(inp), out)
+                self.assertEqual(aux.ensure_url_prefix(inp), out)
             except Exception:
                 print('Failed with:', inp, out)
                 raise

--- a/tests/test_auxiliary.py
+++ b/tests/test_auxiliary.py
@@ -5,6 +5,7 @@ import operator as op
 import numpy as np
 import pandas as pd
 import tempfile
+import platform
 
 from os import path
 import pyteomics
@@ -37,10 +38,8 @@ class QvalueTest(unittest.TestCase):
         self.assertTrue(np.allclose(q['score'], np.arange(52)))
         self.setUp()
         spsms = sorted(self.psms, key=self.key)
-        self.assertTrue(np.allclose([self.is_decoy(x) for x in spsms],
-            q['is decoy']))
-        self.assertTrue(np.allclose([self.key(x) for x in spsms],
-            q['score']))
+        self.assertTrue(np.allclose([self.is_decoy(x) for x in spsms], q['is decoy']))
+        self.assertTrue(np.allclose([self.key(x) for x in spsms], q['score']))
         self.setUp()
 
     def _run_check_pep(self, q):
@@ -80,8 +79,7 @@ class QvalueTest(unittest.TestCase):
         psms = np.array(list(self.psms), dtype=dtype)
         q = aux.qvalues(psms, key=self.key, is_decoy=self.is_decoy, remove_decoy=False, formula=1)
         self._run_check(q, 1)
-        q = aux.qvalues(psms, key=self.key, is_decoy=self.is_decoy, remove_decoy=False, formula=1,
-            full_output=True)
+        q = aux.qvalues(psms, key=self.key, is_decoy=self.is_decoy, remove_decoy=False, formula=1, full_output=True)
         self._run_check(q, 1)
         self.assertTrue(q['psm'].dtype == dtype)
 
@@ -123,8 +121,7 @@ class QvalueTest(unittest.TestCase):
         psms = np.array(list(self.psms), dtype=dtype)
         q = aux.qvalues(psms, key='score', is_decoy=self.is_decoy, remove_decoy=False, formula=1)
         self._run_check(q, 1)
-        q = aux.qvalues(psms, key='score', is_decoy=self.is_decoy, remove_decoy=False, formula=1,
-            full_output=True)
+        q = aux.qvalues(psms, key='score', is_decoy=self.is_decoy, remove_decoy=False, formula=1, full_output=True)
         self._run_check(q, 1)
         self.assertTrue(q['psm'].dtype == dtype)
 
@@ -143,8 +140,7 @@ class QvalueTest(unittest.TestCase):
         psms = pd.DataFrame(np.array(list(self.psms), dtype=dtype))
         q = aux.qvalues(psms, key='score', is_decoy=self.is_decoy, remove_decoy=False, formula=1)
         self._run_check(q, 1)
-        q = aux.qvalues(psms, key='score', is_decoy=self.is_decoy, remove_decoy=False, formula=1,
-            full_output=True)
+        q = aux.qvalues(psms, key='score', is_decoy=self.is_decoy, remove_decoy=False, formula=1, full_output=True)
         self._run_check(q, 1)
 
     def test_qvalues_pep_from_dataframe_string_pep(self):
@@ -163,8 +159,7 @@ class QvalueTest(unittest.TestCase):
         psms['is decoy'] = [self.is_decoy(row) for _, row in psms.iterrows()]
         q = aux.qvalues(psms, key='score', is_decoy='is decoy', remove_decoy=False, formula=1)
         self._run_check(q, 1)
-        q = aux.qvalues(psms, key='score', is_decoy='is decoy', remove_decoy=False, formula=1,
-            full_output=True)
+        q = aux.qvalues(psms, key='score', is_decoy='is decoy', remove_decoy=False, formula=1, full_output=True)
         self._run_check(q, 1)
 
     def test_qvalues_pep_from_dataframe_string_key_and_pep(self):
@@ -176,12 +171,9 @@ class QvalueTest(unittest.TestCase):
         self._run_check_pep(q)
 
     def test_qvalues_pep_exceptions(self):
-        self.assertRaises(aux.PyteomicsError, aux.qvalues,
-            self.psms, pep='pep', is_decoy=self.is_decoy)
-        self.assertRaises(aux.PyteomicsError, aux.qvalues,
-            self.psms, pep='pep', remove_decoy=False)
-        self.assertRaises(aux.PyteomicsError, aux.qvalues,
-            self.psms, pep='pep', correction=0)
+        self.assertRaises(aux.PyteomicsError, aux.qvalues, self.psms, pep='pep', is_decoy=self.is_decoy)
+        self.assertRaises(aux.PyteomicsError, aux.qvalues, self.psms, pep='pep', remove_decoy=False)
+        self.assertRaises(aux.PyteomicsError, aux.qvalues, self.psms, pep='pep', correction=0)
 
     def test_qvalues_from_tandem(self):
         psms = tandem.TandemXML('test.t.xml')
@@ -259,13 +251,13 @@ class FilterTest(unittest.TestCase):
 
     def test_filter_chain_with(self):
         with aux.filter.chain(self.psms, self.psms, key=self.key, is_decoy=self.is_decoy,
-            fdr=0.5, full_output=False) as f:
+                              fdr=0.5, full_output=False) as f:
             f1 = list(f)
         self.assertEqual(len(f1), 52)
 
     def test_filter_pep_chain_with(self):
         with aux.filter.chain(self.psms, self.psms, pep=self.pep,
-            fdr=0.02, full_output=False) as f:
+                              fdr=0.02, full_output=False) as f:
             f1 = list(f)
         self.assertEqual(len(f1), 42)
 
@@ -304,14 +296,12 @@ class FilterTest(unittest.TestCase):
         self.assertEqual(f.shape[0], 42)
 
     def test_filter_chain_from_iterable_with(self):
-        with aux.filter.chain.from_iterable([self.psms, self.psms],
-            key=self.key, is_decoy=self.is_decoy, fdr=0.5, full_output=False) as f:
+        with aux.filter.chain.from_iterable([self.psms, self.psms], key=self.key, is_decoy=self.is_decoy, fdr=0.5, full_output=False) as f:
             f11 = list(f)
         self.assertEqual(len(f11), 52)
 
     def test_filter_pep_chain_from_iterable_with(self):
-        with aux.filter.chain.from_iterable([self.psms, self.psms],
-            key=self.key, pep=self.pep, fdr=0.02, full_output=False) as f:
+        with aux.filter.chain.from_iterable([self.psms, self.psms], key=self.key, pep=self.pep, fdr=0.02, full_output=False) as f:
             f1 = list(f)
         self.assertEqual(len(f1), 42)
 
@@ -745,7 +735,6 @@ class FilterTest(unittest.TestCase):
 
 
 class FDRTest(unittest.TestCase):
-
     is_decoy = staticmethod(lambda x: x[1].islower())
     pep = staticmethod(op.itemgetter(2))
 
@@ -985,6 +974,33 @@ class VersionTest(unittest.TestCase):
 
     def test_longer_dev_version(self):
         self.assertEqual(version.VersionInfo('1.2.3dev4'), ('1', '2', '3', 'dev', '4'))
+
+
+class UtilTest(unittest.TestCase):
+    def test_ensure_prefix(self):
+        pairs = [
+            ('file:///home/test/unimod.xml', 'file:///home/test/unimod.xml'),
+            ('https://example.org/test/unimod.xml', 'https://example.org/test/unimod.xml'),
+            ('ftp://example.org/test/unimod.xml', 'ftp://example.org/test/unimod.xml'),
+            ('http://example.org/test/unimod.xml', 'http://example.org/test/unimod.xml'),
+        ]
+        pairs_windows = [
+            ('C:/Data folder/unimod.xml', 'file:///C:/Data folder/unimod.xml'),
+            ('file:///C:/Data folder/unimod.xml', 'file:///C:/Data folder/unimod.xml'),
+        ]
+        pairs_other = [('/home/test/unimod.xml', 'file:///home/test/unimod.xml'),]
+        system = platform.system()
+        print('Testing on', system)
+        if system == 'Windows':
+            pairs.extend(pairs_windows)
+        else:
+            pairs.extend(pairs_other)
+        for inp, out in pairs:
+            try:
+                self.assertEqual(aux.ensure_prefix(inp), out)
+            except Exception:
+                print('Failed with:', inp, out)
+                raise
 
 
 import warnings

--- a/tests/test_auxiliary.py
+++ b/tests/test_auxiliary.py
@@ -5,11 +5,9 @@ import operator as op
 import numpy as np
 import pandas as pd
 import tempfile
-import platform
-
-from os import path
+import os
 import pyteomics
-pyteomics.__path__ = [path.abspath(path.join(path.dirname(__file__), path.pardir, 'pyteomics'))]
+pyteomics.__path__ = [os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir, 'pyteomics'))]
 from pyteomics import auxiliary as aux
 from pyteomics import tandem
 from pyteomics import version
@@ -974,33 +972,6 @@ class VersionTest(unittest.TestCase):
 
     def test_longer_dev_version(self):
         self.assertEqual(version.VersionInfo('1.2.3dev4'), ('1', '2', '3', 'dev', '4'))
-
-
-class UtilTest(unittest.TestCase):
-    def test_ensure_prefix(self):
-        pairs = [
-            ('file:///home/test/unimod.xml', 'file:///home/test/unimod.xml'),
-            ('https://example.org/test/unimod.xml', 'https://example.org/test/unimod.xml'),
-            ('ftp://example.org/test/unimod.xml', 'ftp://example.org/test/unimod.xml'),
-            ('http://example.org/test/unimod.xml', 'http://example.org/test/unimod.xml'),
-        ]
-        pairs_windows = [
-            ('C:/Data folder/unimod.xml', 'file:///C:/Data folder/unimod.xml'),
-            ('file:///C:/Data folder/unimod.xml', 'file:///C:/Data folder/unimod.xml'),
-        ]
-        pairs_other = [('/home/test/unimod.xml', 'file:///home/test/unimod.xml'),]
-        system = platform.system()
-        print('Testing on', system)
-        if system == 'Windows':
-            pairs.extend(pairs_windows)
-        else:
-            pairs.extend(pairs_other)
-        for inp, out in pairs:
-            try:
-                self.assertEqual(aux.ensure_url_prefix(inp), out)
-            except Exception:
-                print('Failed with:', inp, out)
-                raise
 
 
 import warnings

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,37 @@
+import unittest
+import platform
+import os
+import pyteomics
+pyteomics.__path__ = [os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir, 'pyteomics'))]
+from pyteomics import auxiliary as aux
+
+
+class UtilTest(unittest.TestCase):
+    def test_ensure_prefix(self):
+        pairs = [
+            ('file:///home/test/unimod.xml', 'file:///home/test/unimod.xml'),
+            ('https://example.org/test/unimod.xml', 'https://example.org/test/unimod.xml'),
+            ('ftp://example.org/test/unimod.xml', 'ftp://example.org/test/unimod.xml'),
+            ('http://example.org/test/unimod.xml', 'http://example.org/test/unimod.xml'),
+        ]
+        pairs_windows = [
+            ('C:/Data folder/unimod.xml', 'file:///C:/Data folder/unimod.xml'),
+            ('file:///C:/Data folder/unimod.xml', 'file:///C:/Data folder/unimod.xml'),
+        ]
+        pairs_other = [('/home/test/unimod.xml', 'file:///home/test/unimod.xml'),]
+        system = platform.system()
+        print('Testing on', system)
+        if system == 'Windows':
+            pairs.extend(pairs_windows)
+        else:
+            pairs.extend(pairs_other)
+        for inp, out in pairs:
+            try:
+                self.assertEqual(aux.ensure_url_prefix(inp), out)
+            except Exception:
+                print('Failed with:', inp, out)
+                raise
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -16,7 +16,7 @@ class UtilTest(unittest.TestCase):
         ]
         pairs_windows = [
             ('C:/Data folder/unimod.xml', 'file:///C:/Data%20folder/unimod.xml'),
-            ('file:///C:/Data folder/unimod.xml', 'file:///C:/Data%20folder/unimod.xml'),
+            ('file:///C:/Data folder/unimod.xml', 'file:///C:/Data older/unimod.xml'),
         ]
         pairs_other = [('/home/test/unimod.xml', 'file:///home/test/unimod.xml'),]
         system = platform.system()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -16,7 +16,7 @@ class UtilTest(unittest.TestCase):
         ]
         pairs_windows = [
             ('C:/Data folder/unimod.xml', 'file:///C:/Data%20folder/unimod.xml'),
-            ('file:///C:/Data folder/unimod.xml', 'file:///C:/Data older/unimod.xml'),
+            ('file:///C:/Data folder/unimod.xml', 'file:///C:/Data folder/unimod.xml'),
         ]
         pairs_other = [('/home/test/unimod.xml', 'file:///home/test/unimod.xml'),]
         system = platform.system()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -15,8 +15,8 @@ class UtilTest(unittest.TestCase):
             ('http://example.org/test/unimod.xml', 'http://example.org/test/unimod.xml'),
         ]
         pairs_windows = [
-            ('C:/Data folder/unimod.xml', 'file:///C:/Data folder/unimod.xml'),
-            ('file:///C:/Data folder/unimod.xml', 'file:///C:/Data folder/unimod.xml'),
+            ('C:/Data folder/unimod.xml', 'file:///C:/Data%20folder/unimod.xml'),
+            ('file:///C:/Data folder/unimod.xml', 'file:///C:/Data%20folder/unimod.xml'),
         ]
         pairs_other = [('/home/test/unimod.xml', 'file:///home/test/unimod.xml'),]
         system = platform.system()


### PR DESCRIPTION
Closes #162.

This checks  that the path passed to `mass.Unimod` has a URL prefix, and adds `file:` if no prefix is specified. It also converts a local path to an absolute one and adds support for `Path` arguments.
