### PR TITLE
Make start method for map() configurable, avoid fork by default

### DIFF
--- a/doc/source/data/indexing.rst.inc
+++ b/doc/source/data/indexing.rst.inc
@@ -164,3 +164,20 @@ and :py:meth:`iterfind`::
     controllerType=0 controllerNumber=1 scan=2
     controllerType=0 controllerNumber=1 scan=1
     controllerType=0 controllerNumber=1 scan=2
+
+Start method
+............
+
+There are different `methods to start new processes <https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods>`_,
+depending on the platform, and this will affect how the mapped function works (e.g. whether it can access global variables). Since version 5.0,
+Pyteomics allows you to configure the start method using :py:func:`pyteomics.auxiliary.set_start_method`.
+Unlike :py:func:`multiprocessing.set_start_method`, it will only set the start method for Pyteomics. If you instead want to call
+:py:func:`multiprocessing.set_start_method` and have it affect Pyteomics, you should make the call before importing Pyteomics.
+
+If :py:func:`pyteomics.auxiliary.set_start_method` is not called, the default start method will generally be preserved, unless it is `fork`,
+in which case it will be changed to `forkserver`. This is because the use of `fork` is `considered unsafe <https://github.com/python/cpython/issues/84559>`_
+in a multithreaded context. See also `this thread <https://discuss.python.org/t/concerns-regarding-deprecation-of-fork-with-alive-threads/33555>`_
+for a more extensive discussion.
+Note that `starting with Python 3.14 <https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-multiprocessing-start-method>`_,
+`fork` will not be the default on any platform. Pyteomics 5.0 makes this change happen sooner, while also giving you an option to take responsibility and
+use the start method you want on any Python version.

--- a/pyteomics/auxiliary/__init__.py
+++ b/pyteomics/auxiliary/__init__.py
@@ -11,7 +11,7 @@ from .file_helpers import (
     FileReader, IndexedTextReader, IndexedReaderMixin, TimeOrderedIndexedReaderMixin,
     IndexSavingMixin, OffsetIndex, HierarchicalOffsetIndex, IndexSavingTextReader,
     _file_reader, _file_writer,
-    _make_chain, _check_use_index, FileReadingProcess, TaskMappingMixin,set_start_method,
+    _make_chain, _check_use_index, FileReadingProcess, TaskMappingMixin, set_start_method,
     serializer, ChainBase, TableJoiner)
 
 from .math import (

--- a/pyteomics/auxiliary/__init__.py
+++ b/pyteomics/auxiliary/__init__.py
@@ -11,7 +11,7 @@ from .file_helpers import (
     FileReader, IndexedTextReader, IndexedReaderMixin, TimeOrderedIndexedReaderMixin,
     IndexSavingMixin, OffsetIndex, HierarchicalOffsetIndex, IndexSavingTextReader,
     _file_reader, _file_writer,
-    _make_chain, _check_use_index, FileReadingProcess, TaskMappingMixin,
+    _make_chain, _check_use_index, FileReadingProcess, TaskMappingMixin,set_start_method,
     serializer, ChainBase, TableJoiner)
 
 from .math import (

--- a/pyteomics/auxiliary/file_helpers.py
+++ b/pyteomics/auxiliary/file_helpers.py
@@ -36,7 +36,19 @@ else:
 from .structures import PyteomicsError
 from .utils import add_metaclass
 
-ctx = mp.get_context('spawn')
+
+def _get_default_start_method():
+    supported_methods = mp.get_all_start_methods()
+    if supported_methods[0] == 'fork':
+        for alternative in ['forkserver', 'spawn']:
+            if alternative in supported_methods:
+                return alternative
+        else:
+            raise RuntimeError('Cannot determine a suitable process start method.')
+    return supported_methods[0]
+
+
+ctx = mp.get_context(_get_default_start_method())
 
 
 def set_start_method(method):

--- a/pyteomics/auxiliary/file_helpers.py
+++ b/pyteomics/auxiliary/file_helpers.py
@@ -36,6 +36,8 @@ else:
 from .structures import PyteomicsError
 from .utils import add_metaclass
 
+ctx = mp.get_context('spawn')
+
 
 def _keepstate(func):
     """Decorator to help keep the position in open files passed as
@@ -939,7 +941,7 @@ def _check_use_index(source, use_index, default):
         return use_index
 
 
-class FileReadingProcess(mp.Process):
+class FileReadingProcess(ctx.Process):
     """Process that does a share of distributed work on entries read from file.
     Reconstructs a reader object, parses an entries from given indexes,
     optionally does additional processing, sends results back.
@@ -956,7 +958,7 @@ class FileReadingProcess(mp.Process):
         self._qin = qin
         self._qout = qout
         # self._in_flag = in_flag
-        self._done_flag = mp.Event()
+        self._done_flag = ctx.Event()
         self.daemon = True
 
     def run(self):
@@ -1090,8 +1092,8 @@ class TaskMappingMixin(NoOpBaseReader):
 
         serialized = self._build_worker_spec(target, args, kwargs)
 
-        in_queue = mp.Queue(self._queue_size)
-        out_queue = mp.Queue(self._queue_size)
+        in_queue = ctx.Queue(self._queue_size)
+        out_queue = ctx.Queue(self._queue_size)
 
         workers = self._spawn_workers(serialized, in_queue, out_queue, processes)
         feeder_thread = self._spawn_feeder_thread(in_queue, iterator, processes)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,6 +2,7 @@ import unittest
 import platform
 import os
 import pyteomics
+import multiprocessing as mp
 pyteomics.__path__ = [os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir, 'pyteomics'))]
 from pyteomics import auxiliary as aux
 
@@ -31,6 +32,11 @@ class UtilTest(unittest.TestCase):
             except Exception:
                 print('Failed with:', inp, out)
                 raise
+
+    def test_start_method(self):
+        self.assertNotEqual(aux.file_helpers._get_default_start_method(), 'fork')
+        if mp.get_start_method(allow_none=False) != 'fork':
+            self.assertEqual(mp.get_start_method(allow_none=False), aux.file_helpers._get_default_start_method())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently, the tests invoking `map()` method of readers produce `DeprecationWarning` on Linux:

```
/usr/lib/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=59787) is multi-threaded, use of fork() may lead to deadlocks in the child.
  self.pid = os.fork()
```

That is because the implementation of `TaskMappingMixin` spawns both threads and processes, and the default method of spawning processes on Linux is currently `fork`, which is considered generally unsafe in a multi-threaded context. Currently `os.fork()` raises a warning when it detects multiple threads, and in Python 3.14 the default for Linux will apparently change to `spawn`, as it already is on Windows and macOS.

Discussion on the matter: https://discuss.python.org/t/concerns-regarding-deprecation-of-fork-with-alive-threads/33555
See also: https://github.com/python/cpython/issues/84559

This change enforces the `spawn` context explicitly, which silences the warning and ensures identical behavior on all platforms and current and future Python versions. However, it will probably make things slower on Linux.

Any comments or alternative suggestions are welcome.