### PR TITLE
Support more varied forms of modification positioning in ProteoformCombinator

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-5.0b4
+5.0b5
 -----
 
  - Support **ProForma 2.1** (`#183 <https://github.com/levitsky/pyteomics/pull/183>`_ by Joshua Klein).

--- a/pyteomics/proforma.py
+++ b/pyteomics/proforma.py
@@ -4023,7 +4023,7 @@ class ProteoformCombinator:
                 self.template[i] = (aa, tags)
         self.template.fixed_modifications.clear()
 
-    def _extract_rules(self) -> List[GeneratorModificationRuleDirective]:
+    def _extract_rules(self) -> None:
         rules = []
         remains = []
         for iv in self.template.intervals:

--- a/pyteomics/version.py
+++ b/pyteomics/version.py
@@ -19,7 +19,7 @@ Constants
 
 """
 
-__version__ = '5.0b4'
+__version__ = '5.0b5'
 
 from collections import namedtuple
 import re

--- a/tests/test_proforma.py
+++ b/tests/test_proforma.py
@@ -485,20 +485,26 @@ class ProteoformCombinatorTest(unittest.TestCase):
     def test_range(self):
         seq = "EMEV(TS)[Phospho]ESPEK"
         pf = ProForma.parse(seq)
-        proteoforms = list(pf.generate_proteoforms())
-        self.assertEqual(len(proteoforms), 2)   # Phospho on T or S
+        for include_unmodified in [False, True]:
+            with self.subTest(include_unmodified=include_unmodified):
+                proteoforms = list(pf.generate_proteoforms(include_unmodified=include_unmodified))
+                self.assertEqual(len(proteoforms), 2 + include_unmodified)   # Phospho on T or S (+ no phospho if include_unmodified)
 
     def test_localization_tag(self):
         seq = "EMEVT[#g1]S[#g1]ES[Phospho#g1]PEK"
         pf = ProForma.parse(seq)
-        proteoforms = list(pf.generate_proteoforms())
-        self.assertEqual(len(proteoforms), 3)
+        for include_unmodified in [False, True]:
+            with self.subTest(include_unmodified=include_unmodified):
+                proteoforms = list(pf.generate_proteoforms(include_unmodified=include_unmodified))
+                self.assertEqual(len(proteoforms), 3 + include_unmodified)
 
     def test_unlocalized_modification(self):
         seq = "[Phospho]?EMEVTSESPEK"
         pf = ProForma.parse(seq)
-        proteoforms = list(pf.generate_proteoforms())
-        self.assertEqual(len(proteoforms), len(pf))
+        for include_unmodified in [False, True]:
+            with self.subTest(include_unmodified=include_unmodified):
+                proteoforms = list(pf.generate_proteoforms(include_unmodified=include_unmodified))
+                self.assertEqual(len(proteoforms), len(pf) + include_unmodified)
 
     def test_comup_stacking(self):
         seq = "[Phospho|Position:S|Position:T|comup|Limit:2]^2?EMEVTESPEK"


### PR DESCRIPTION
This adds extra behavior to to `ProteoformCombinator` to support modifications with uncertain positions defined by group IDs or for tagged intervals. It addresses the failing tests in #189.

I think this still needs work because the default behavior before assumed the user wanted both the modified and unmodified forms of a peptide, as you might get from a variable modification rule in a search engine. The failing tests assumed that was not the case. I think I can square these two use-cases more elegantly, but I only had about an hour to work on it tonight.