### PR TITLE
Fix XML indexing for explicit namespaces

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -55,6 +55,7 @@
  - Add an `absolute` parameter (True by default) for :py:func:`pyteomics.mass.fast_mass` and :py:func:`pyteomics.mass.fast_mass2`.
  - Allow fragment charges formatted as :py:class:`float` in MGF (issue `#185 <https://github.com/levitsky/pyteomics/issues/185>`_).
  - New functions :py:func:`pyteomics.parser.coverage_mask` and :py:func:`pyteomics.parser.strip`.
+ - Add support for explicit XML namespaces (`#200 <https://github.com/levitsky/pyteomics/issues/200>_`).
 
 
 4.7.5

--- a/pyteomics/xml.py
+++ b/pyteomics/xml.py
@@ -51,6 +51,10 @@ def _local_name(element):
     tag = element.tag
     if tag and tag[0] == '{':
         return tag.rpartition('}')[2]
+    # When parsing XML fragments without in-scope namespace declarations,
+    # lxml may leave prefixed names in "prefix:local" form.
+    if tag and ':' in tag:
+        return tag.rsplit(':', 1)[1]
     return tag
 
 
@@ -942,7 +946,8 @@ class ByteCountingXMLScanner(_file_obj):
         """
         i = 0
         packed = b"|".join(self.indexed_tags)
-        pattern = re.compile((r"^\s*<(%s)\s" % packed.decode()).encode())
+        # Allow optional namespace prefix (e.g., ns0:) before tag name
+        pattern = re.compile((r"^\s*<(?:\w+:)?(%s)\s" % packed.decode()).encode())
         attrs = re.compile(br"(\S+)=[\"']([^\"']*)[\"']")
         for line in self._chunk_iterator():
             match = pattern.match(line)

--- a/tests/rewrite_default_ns.sh
+++ b/tests/rewrite_default_ns.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: rewrite_default_ns.sh [-p PREFIX] [-o OUTPUT] INPUT
+
+Rewrite XML so elements in the document's default namespace are explicitly prefixed
+(default prefix: ns0), then validate the result.
+
+Options:
+  -p PREFIX   Namespace prefix to use (default: ns0)
+  -o OUTPUT   Output file path (default: INPUT with suffix .explicit-ns.xml)
+  -h          Show this help
+EOF
+}
+
+require_cmd() {
+    local cmd="$1"
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "Error: required command not found: $cmd" >&2
+        exit 1
+    fi
+}
+
+prefix="ns0"
+output=""
+
+while getopts ":p:o:h" opt; do
+    case "$opt" in
+        p)
+            prefix="$OPTARG"
+            ;;
+        o)
+            output="$OPTARG"
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        :)
+            echo "Error: option -$OPTARG requires an argument." >&2
+            usage >&2
+            exit 2
+            ;;
+        \?)
+            echo "Error: invalid option -$OPTARG" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+shift $((OPTIND - 1))
+
+if [[ $# -ne 1 ]]; then
+    usage >&2
+    exit 2
+fi
+
+input="$1"
+
+if [[ ! -f "$input" ]]; then
+    echo "Error: input file does not exist: $input" >&2
+    exit 1
+fi
+
+if [[ ! "$prefix" =~ ^[A-Za-z_][A-Za-z0-9_.-]*$ ]]; then
+    echo "Error: invalid XML prefix: $prefix" >&2
+    exit 1
+fi
+
+if [[ -z "$output" ]]; then
+    output="${input%.*}.explicit-ns.xml"
+fi
+
+require_cmd xmllint
+require_cmd xmlstarlet
+require_cmd mktemp
+
+default_ns_uri="$(xmllint --xpath 'namespace-uri(/*)' "$input" 2>/dev/null || true)"
+if [[ -z "$default_ns_uri" ]]; then
+    echo "Error: input root element does not have a default namespace." >&2
+    exit 1
+fi
+
+tmp_xslt="$(mktemp)"
+trap 'rm -f "$tmp_xslt"' EXIT
+
+cat > "$tmp_xslt" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:${prefix}="${default_ns_uri}"
+    exclude-result-prefixes="${prefix}">
+  <xsl:output method="xml" indent="yes"/>
+  <xsl:strip-space elements="*"/>
+
+  <xsl:template match="@*|text()|comment()|processing-instruction()">
+    <xsl:copy/>
+  </xsl:template>
+
+  <xsl:template match="@*">
+    <xsl:choose>
+      <xsl:when test="namespace-uri() = '${default_ns_uri}'">
+        <xsl:attribute name="${prefix}:{local-name()}" namespace="${default_ns_uri}">
+          <xsl:value-of select="."/>
+        </xsl:attribute>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="*">
+    <xsl:choose>
+      <xsl:when test="namespace-uri() = '${default_ns_uri}'">
+        <xsl:element name="${prefix}:{local-name()}" namespace="${default_ns_uri}">
+          <xsl:apply-templates select="@*|node()"/>
+        </xsl:element>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy>
+          <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+</xsl:stylesheet>
+EOF
+
+xmlstarlet tr "$tmp_xslt" "$input" > "$output"
+
+# Validation 1: well-formed XML
+xmllint --noout "$output"
+
+# Validation 2: root is prefixed with requested prefix
+root_name="$(xmllint --xpath 'name(/*)' "$output" 2>/dev/null)"
+if [[ "$root_name" != ${prefix}:* ]]; then
+    echo "Error: output root element is not explicitly prefixed with '${prefix}'." >&2
+    exit 1
+fi
+
+# Validation 3: no default namespace declaration on root
+default_decl_count="$(xmllint --xpath 'count(/*/namespace::*[name()=""])' "$output" 2>/dev/null)"
+if [[ "$default_decl_count" != "0" ]]; then
+    echo "Error: output still has a default namespace declaration on the root element." >&2
+    exit 1
+fi
+
+echo "Success: wrote '$output' with explicit namespace prefix '$prefix'."
+echo "Validated: XML is well-formed, root is prefixed, default namespace declaration removed from root."

--- a/tests/test.explicit-ns.mzid
+++ b/tests/test.explicit-ns.mzid
@@ -1,0 +1,634 @@
+<?xml version="1.0"?>
+<!-- edited with XMLSpy v2011 (http://www.altova.com) by Gerhard Mayer (MPC Bochum) -->
+<ns0:MzIdentML xmlns:ns0="http://psidev.info/psi/pi/mzIdentML/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="MPC_use_case_handcrafted" name="MPC_example" creationDate="2011-03-25T16:15:00" version="1.1.0" xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.1 ../../schema/mzIdentML1.1.0.xsd">
+  <!-- CAUTION: ALL experimentalMassToCharge, peptide scores, protein scores and sequence coverage and spectrumID values are only placeholders for the real values, because file is handcrafted and shows only principle structure of mzIdentML! -->
+  <ns0:cvList>
+    <ns0:cv id="PSI-MS" fullName="Proteomics Standards Initiative Mass Spectrometry Vocabularies" uri=" http://psidev.cvs.sourceforge.net/viewvc/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo" version="2.25.0"/>
+    <ns0:cv id="BTO" fullName="BRENDA tissue 7 enzyme source" uri="http://www.brenda-enzymes.info/" version="12/2007"/>
+    <ns0:cv id="UNIMOD" fullName="UNIMOD CV for modifications" uri="http://www.unimod.org/obo/unimod.obo"/>
+    <ns0:cv id="UO" fullName="Unit Ontology" uri="http://obo.cvs.sourceforge.net/*checkout*/obo/obo/ontology/phenotype/unit.obo"/>
+  </ns0:cvList>
+  <ns0:AnalysisSoftwareList>
+    <ns0:AnalysisSoftware id="SEQUEST_SW" name="ThermoFisher TurboSequest" version="PVM Slave v.27 (rev. 12)" uri="http://www.thermo.com/com/cda/product/detail/1,,16483,00.html">
+      <ns0:ContactRole contact_ref="THERMO">
+        <ns0:Role>
+          <ns0:cvParam accession="MS:1001267" name="software vendor" cvRef="PSI-MS"/>
+        </ns0:Role>
+      </ns0:ContactRole>
+      <ns0:SoftwareName>
+        <ns0:cvParam accession="MS:1001208" name="Sequest" cvRef="PSI-MS"/>
+      </ns0:SoftwareName>
+    </ns0:AnalysisSoftware>
+    <ns0:AnalysisSoftware id="Mascot_SW" name="Mascot" version="2.2.0" uri="http://www.matrixscience.com/">
+      <ns0:ContactRole contact_ref="MATRIXSCIENCE">
+        <ns0:Role>
+          <ns0:cvParam accession="MS:1001267" name="software vendor" cvRef="PSI-MS"/>
+        </ns0:Role>
+      </ns0:ContactRole>
+      <ns0:SoftwareName>
+        <ns0:cvParam accession="MS:1001207" name="Mascot" cvRef="PSI-MS"/>
+      </ns0:SoftwareName>
+    </ns0:AnalysisSoftware>
+    <ns0:AnalysisSoftware id="ProteinExtractor_SW" name="ProteinExtractor">
+      <ns0:ContactRole contact_ref="BRUKER">
+        <ns0:Role>
+          <ns0:cvParam accession="MS:1001267" name="software vendor" cvRef="PSI-MS"/>
+        </ns0:Role>
+      </ns0:ContactRole>
+      <ns0:SoftwareName>
+        <ns0:cvParam accession="MS:1000734" name="ProteinScape" cvRef="PSI-MS"/>
+      </ns0:SoftwareName>
+    </ns0:AnalysisSoftware>
+  </ns0:AnalysisSoftwareList>
+  <ns0:Provider id="MPCProvider">
+    <ns0:ContactRole contact_ref="MPCMEYER">
+      <ns0:Role>
+        <ns0:cvParam accession="MS:1001271" name="researcher" cvRef="PSI-MS"/>
+      </ns0:Role>
+    </ns0:ContactRole>
+  </ns0:Provider>
+  <ns0:AuditCollection>
+    <ns0:Organization id="BRUKER" name="Bruker Daltonics GmbH">
+      <ns0:cvParam accession="MS:1000587" name="contact address" cvRef="PSI-MS" value="Bremen, Germany"/>
+    </ns0:Organization>
+    <ns0:Organization id="MATRIXSCIENCE" name="MatrixScience">
+      <ns0:cvParam accession="MS:1000587" name="contact address" cvRef="PSI-MS" value="UK"/>
+    </ns0:Organization>
+    <ns0:Organization id="THERMO" name="Thermo Corp.">
+      <ns0:cvParam accession="MS:1000587" name="contact address" cvRef="PSI-MS" value="USA"/>
+    </ns0:Organization>
+    <ns0:Person id="MPCMEYER" name="Prof. Dr. Helmut E. Meyer">
+      <ns0:cvParam accession="MS:1000587" name="contact address" cvRef="PSI-MS" value="Universitaetsstr. 150, D-44795 Bochum, Germany"/>
+      <ns0:cvParam accession="MS:1000589" name="contact email" cvRef="PSI-MS" value="helmut.e.meyer@rub.de"/>
+      <ns0:Affiliation organization_ref="MPCINSTITUTE"/>
+    </ns0:Person>
+    <ns0:Organization id="MPCINSTITUTE" name="Medizinisches Proteom-Center">
+      <ns0:cvParam accession="MS:1000587" name="contact address" cvRef="PSI-MS" value="Bremen, Germany"/>
+      <ns0:Parent organization_ref="RUB"/>
+    </ns0:Organization>
+    <ns0:Organization id="RUB" name="Ruhr-Universitaet Bochum">
+      <ns0:cvParam accession="MS:1000587" name="contact address" cvRef="PSI-MS" value="Universitaetsstr. 150, D-44795 Bochum, Germany"/>
+    </ns0:Organization>
+  </ns0:AuditCollection>
+  <ns0:AnalysisSampleCollection>
+    <ns0:Sample id="sample1">
+      <ns0:cvParam accession="MS:1001467" name="taxonomy: NCBI TaxID" cvRef="PSI-MS" value="9606"/>
+      <ns0:cvParam accession="BTO:0000255" name="brain cell line" cvRef="BTO"/>
+    </ns0:Sample>
+  </ns0:AnalysisSampleCollection>
+  <ns0:SequenceCollection>
+    <ns0:DBSequence id="prot1_IPI" accession="IPI00013808.1" searchDatabase_ref="ipi.HUMAN_decoy">
+      <ns0:Seq>MVDYHAANQSYQYGPSSAGNGAGGGGSMGDYMAQEDDWDRDLLLDPAWEKQQRKTFTAWCNSHLRKAGTQIENIDEDFRDGLKLMLLLEVISGERLPKPERGKMRVHKINNVNKALDFIASKGVKLVSIGAEEIVDGNAKMTLGMIWTIILRFAIQDISVEETSAKEGLLLWCQRKTAPYKNVNVQNFHISWKDGLAFNALIHRHRPELIEYDKLRKDDPVTNLNNAFEVAEKYLDIPKMLDAEDIVNTARPDEKAIMTYVSSFYHAFSGAQKAETAANRICKVLAVNQENEHLMEDYEKLASDLLEWIRRTIPWLEDRVPQKTIQEMQQKLEDFRDYRRVHKPPKVQEKCQLEINFNTLQTKLRLSNRPAFMPSEGKMVSDINNGWQHLEQAEKGYEEWLLNEIRRLERLDHLAEKFRQKASIHEAWTDGKEAMLKHRDYETATLSDIKALIRKHEAFESDLAAHQDRVEQIAAIAQELNELDYYDSHNVNTRCQKICDQWDALGSLTHSRREALEKTEKQLEAIDQLHLEYAKRAAPFNNWMESAMEDLQDMFIVHTIEEIEGLISAHDQFKSTLPDADREREAILAIHKEAQRIAESNHIKLSGSNPYTTVTPQIINSKWEKVQQLVPKRDHALLEEQSKQQSNEHLRRQFASQANVVGPWIQTKMEEIGRISIEMNGTLEDQLSHLKQYERSIVDYKPNLDLLEQQHQLIQEALIFDNKHTNYTMEHIRVGWEQLLTTIARTINEVENQILTRDAKGISQEQMQEFRASFNHFDKDHGGALGPEEFKACLISLGYDVENDRQGEAEFNRIMSLVDPNHSGLVTFQAFIDFMSRETTDTDTADQVIASFKVLAGDKNFITAEELRRELPPDQAEYCIARMAPYQGPDAVPGALDYKSFSTALYGESDL</ns0:Seq>
+      <ns0:cvParam accession="MS:1001088" name="protein description" cvRef="PSI-MS" value="IPI:IPI00013808.1|SWISS-PROT:O43707|TREMBL:Q96BG6|ENSEMBL:ENSP00000252699|REFSEQ:NP_004915|H-INV:HIT000032172|VEGA:OTTHUMP00000076071;OTTHUMP00000174445 Tax_Id=9606 Gene_Symbol=ACTN4 Alpha-actinin-4"/>
+    </ns0:DBSequence>
+    <ns0:DBSequence id="prot2_IPI" accession="IPI00554648.1" searchDatabase_ref="ipi.HUMAN_decoy">
+      <ns0:Seq>SIRVTQKSYKVSTSGPRAFSSRSYTSGPGSRISSSSFSRVGSSNFRGGLGGGYGGASGMGGITAVTVNQSLLSPLVLEVDPNIQAVRTQEKEQIKTLNNKFASFIDKVRFLEQQNKMLETKWSLLQQQKTARSNMDNMFESYINNLRRQLETLGQEKLKLEAELGNMQGLVEDFKNKYEDEINKRTEMENEFVLIKKDVDEAYMNKVELESRLEGLTDEINFLRQLYEEEIRELQSQISDTSVVLSMDNSRSLDMDSIIAEVKAQYEDIANRSRAEAESMYQIKYEELQSLAGKHGDDLRRTKTEISEMNRNISRLQAEIEGLKGQRASLEAAIADAEQRGELAIKDANAKLSELEAALQRAKQDMARQLREYQELMNVKLALDIEIATYRKLLEGEESRLESGMQNMSIHTKTTGGYAGGLSSAYGGLTSPGLSYSLGSSFGSGAGSSSFSRTSSSRAVVVKKIETRDGKLVSESSDVLPK</ns0:Seq>
+      <ns0:cvParam accession="MS:1001088" name="protein description" cvRef="PSI-MS" value="&gt;IPI:IPI00554648.1|SWISS-PROT:P05787 Tax_Id=9606 Keratin, type II cytoskeletal 8"/>
+    </ns0:DBSequence>
+    <ns0:DBSequence id="prot3_IPI" accession="IPI00414676.5" searchDatabase_ref="ipi.HUMAN_decoy">
+      <ns0:Seq>PEEVHHGEEEVETFAFQAEIAQLMSLIINTFYSNKEIFLRELISNASDALDKIRYESLTDPSKLDSGKELKIDIIPNPQERTLTLVDTGIGMTKADLINNLGTIAKSGTKAFMEALQAGADISMIGQFGVGFYSAYLVAEKVVVITKHNDDEQYAWESSAGGSFTVRADHGEPIGRGTKVILHLKEDQTEYLEERRVKEVVKKHSQFIGYPITLYLEKEREKEISDDEAEEEKGEKEEEDKDDEEKPKIEDVGSDEEDDSGKDKKKKTKKIKEKYIDQEELNKTKPIWTRNPDDITQEEYGEFYKSLTNDWEDHLAVKHFSVEGQLEFRALLFIPRRAPFDLFENKKKKNNIKLYVRRVFIMDSCDELIPEYLNFIRGVVDSEDLPLNISREMLQQSKILKVIRKNIVKKCLELFSELAEDKENYKKFYEAFSKNLKLGIHEDSTNRRRLSELLRYHTSQSGDEMTSLSEYVSRMKETQKSIYYITGESKEQVANSAFVERVRKRGFEVVYMTEPIDEYCVQQLKEFDGKSLVSVTKEGLELPEDEEEKKKMEESKAKFENLCKLMKEILDKKVEKVTISNRLVSSPCCIVTSTYGWTANMERIMKAQALRDNSTMGYMMAKKHLEINPDHPIVETLRQKAEADKNDKAVKDLVVLLFETALLSSGFSLEDPQTHSNRIYRMIKLGLGIDEDEVAAEEPNAAVPDEIPPLEGDEDASRMEEVD</ns0:Seq>
+      <ns0:cvParam accession="MS:1001088" name="protein description" cvRef="PSI-MS" value="&gt;IPI:IPI00414676.5|SWISS-PROT:P08238|TREMBL:Q5T9W7;Q6PK50;Q9H6X9|ENSEMBL:ENSP00000325875|REFSEQ:NP_031381|H-INV:HIT000008644;HIT000032091;HIT000034201;HIT000035963;HIT000036733;HIT000049765;HIT000057726|VEGA:OTTHUMP00000016517;OTTHUMP00000016518;OTTHUMP00000016519 Tax_Id=9606 Heat shock protein HSP 90-beta"/>
+    </ns0:DBSequence>
+    <ns0:DBSequence id="prot4_SHD" accession="SHD00382470.3" searchDatabase_ref="ipi.HUMAN_decoy">
+      <ns0:Seq>YQQKTRHDAFPRIQLALRAGAKSKEDLFSEPKLYEDKEQRISSELPEEALDDSSPSDTSLIAVEREISSNLRHSSTNYEEHLRKLKKDKYSEAVDPSGKPLGLLVILGNQYMREDEIATEERMPENKSTDISTYIKEFDGKEIAFPTENSYFPARGDKSKAVTAKWKRFTPFPLQTDDNSAAKLTEVFKIQLTTVGKLGKCSEGGENKEDKCTDNLCLNPPDELTEHREAPVTDTKPIMPEQIIITTKEISDSQLENRDETAPIALDLIALVSVNSLTGETNRKMEEYKSKKRRTTRLEETGFHILHNREVNMDNGECVFPIHYDAAQEMQPHTDSSKVMKASEFQKDIILMELIEKFDHNVKLLSKDCVEVQNSMANLELDKESEEQAVGDGSCLTRGTLVIKAQNGKNTGENDSTKETREYLRKKMDEAEDYGLVLKDDTYIEVWDVAVQITYLLKRSIEWPESECIDIEPFVHKAKSYINVEKETESHKLVQHKYKCRPLFRGENKDVTKRLLYGKILLEDKLSSASGLKSTELWDLDEDYEVTWRQEILLNKNKKVAPDEKETYIVLQNNLYPMQPVVMPSIPARMMSLENDILKMPIAAVRVKVVDITINKFLMGEINADDMEFPTSGFLEQHSDFGGLANGESQNDKPTEGQAREIEPIAKEEYVIDLEWGLRITQPTSEYGYDGELVVYVTKGMGKQTEPESLSYVCVVEGFAKAQLPERQITGKEDSGFIRRQQRLLEDDFSMKKKIFEGLDPILSEKKLDMQFRKFSMKWQYLKDILPADFDKEKEIFREFHKIEIKVSFGHKGMESKAALYIKFYETFERELKQFLSAEPRYRDDACEGLQLEV</ns0:Seq>
+      <ns0:cvParam accession="MS:1001088" name="protein description" cvRef="PSI-MS" value="&gt;SHD:SHD00382470.3|SWISS-PROT:P07900-2|TREMBL:Q86SX1|ENSEMBL:ENSP00000335153|REFSEQ:NP_001017963|VEGA:OTTHUMP00000041671 Tax_Id=9606 Gene_Symbol=HSP90AA1 heat shock protein 90kDa alpha (cytosolic), class A member 1 isoform 1"/>
+    </ns0:DBSequence>
+    <ns0:DBSequence id="prot5_IPI" accession="IPI00398776.3" searchDatabase_ref="ipi.HUMAN_decoy">
+      <ns0:Seq>MKIVPDERDRVQKKTFTKWVNKHLIKAQRHISDLYEDLRDGHNLISLLEVLSGDSLPREKGRMRFHKLQNVQIALDYLRHRQVKLVNIRNDDIADGNPKLTLGLIWTIILHFQISDIQVSGQSEDMTAKEKLLLWSQRMVEGYQGLRCDNFTSSWRDGRLFNAIIHRHKPLLIDMNKVYRQTNLENLDQAFSVAERDLGVTRLLDPEDVDVPQPDEKSIITYVSSLYDAMPRVPDVQDGVRANELQLRWQEYRELVLLLLQWMRHHTAAFEERRFPSSFEEIEILWSQFLKFKEMELPAKEADKNRSKGIYQSLEGAVQAGQLKVPPGYHPLDVEKEWGKLHVAILEREKQLRSEFERLECLQRIVTKLQMEAGLCEEQLNQADALLQSDVRLLAAGKVPQRAGEVERDLDKADSMIRLLFNDVQTLKDGRHPQGEQMYRRVYRLHERLVAIRTEYNLRLKAGVAAPATQVAQVTLQSVQRRPELEDSTLRYLQDLLAWVEENQHRVDGAEWGVDLPSVEAQLGSHRGLHQSIEEFRAKIERARSDEGQLSPATRGAYRDCLGRLDLQYAKLLNSSKARLRSLESLHSFVAAATKELMWLNEKEEEEVGFDWSDRNTNMTAKKESYSALMRELELKEKKIKELQNAGDRLLREDHPARPTVESFQAALQTQWSWMLQLCCCIEAHLKENAAYFQFFSDVREAEGQLQKLQEALRRKYSCDRSATVTRLEDLLQDAQDEKEQLNEYKGHLSGLAKRAKAVVQLKPRHPAHPMRGRLPLLAVCDYKQVEVTVHKGDECQLVGPAQPSHWKVLSSSGSEAAVPSVCFLVPPPNQEAQEAVTRLEAQHQALVTLWHQLHVDMKSLLAWQSLRRDVQLIRSWSLATFRTLKPEEQRQALHSLELHYQAFLRDSQDAGGFGPEDRLMAEREYGSCSHHYQQLLQSLEQGAQEESRCQRCISELKDIRLQLEACETRTVHRLRLPLDKEPARECAQRIAEQQKAQAEVEGLGKGVARLSAEAEKVLALPEPSPAAPTLRSELELTLGKLEQVRSLSAIYLEKLKTISLVIRGTQGAEEVLRAHEEQLKEAQAVPATLPELEATKASLKKLRAQAEAQQPTFDALRDELRGAQEVGERLQQRHGERDVEVERWRERVAQLLERWQAVLAQTDVRQRELEQLGRQLRYYRESADPLGAWLQDARRRQEQIQAMPLADSQAVREQLRQEQALLEEIERHGEKVEECQRFAKQYINAIKDYELQLVTYKAQLEPVASPAKKPKVQSGSESVIQEYVDLRTHYSELTTLTSQYIKFISETLRRMEEEERLAEQQRAEERERLAEVEAALEKQRQLAEAHAQAKAQAEREAKELQQRMQEEVVRREEAAVDAQQQKRSIQEELQQLRQSSEAEIQAKARQAEAAERSRLRIEEEIRVVRLQLEATERQRGGAEGELQALRARAEEAEAQKRQAQEEAERLRRQVQDESQRKRQAEVELASRVKAEAEAAREKQRALQALEELRLQAEEAERRLRQAEVERARQVQVALETAQRSAEAELQSKRASFAEKTAQLERSLQEEHVAVAQLREEAERRAQQQAEAERAREEAERELERWQLKANEALRLRLQAEEVAQQKSLAQAEAEKQKEEAEREARRRGKAEEQAVRQRELAEQELEKQRQLAEGTAQQRLAAEQELIRLRAETEQGEQQRQLLEEELARLQREAAAATQKRQELEAELAKVRAEMEVLLASKARAEEESRSTSEKSKQRLEAEAGRFRELAEEAARLRALAEEAKRQRQLAEEDAARQRAEAERVLAEKLAAIGEATRLKTEAEIALKEKEAENERLRRLAEDEAFQRRRLEEQAAQHKADIEERLAQLRKASDSELERQKGLVEDTLRQRRQVEEEILALKASFEKAAAGKAELELELGRIRSNAEDTLRSKEQAELEAARQRQLAAEEERRRREAEERVQKSLAAEEEAARQRKAALEEVERLKAKVEEARRLRERAEQESARQLQLAQEAAQKRLQAEEKAHAFAVQQKEQELQQTLQQEQSVLDQLRGEAEAARRAAEEAEEARVQAEREAAQSRRQVEEAERLKQSAEEQAQARAQAQAAAEKLRKEAEQEAARRAQAEQAALRQKQAADAEMEKHKKFAEQTLRQKAQVEQELTTLRLQLEETDHQKNLLDEELQRLKAEATEAARQRSQVEEELFSVRVQMEELSKLKARIEAENRALILRDKDNTQRFLQEEAEKMKQVAEEAARLSVAAQEAARLRQLAEEDLAQQRALAEKMLKEKMQAVQEATRLKAEAELLQQQKELAQEQARRLQEDKEQMAQQLAEETQGFQRTLEAERQRQLEMSAEAERLKLRVAEMSRAQARAEEDAQRFRKQAEEIGEKLHRTELATQEKVTLVQTLEIQRQQSDHDAERLREAIAELEREKEKLQQEAKLLQLKSEEMQTVQQEQLLQETQALQQSFLSEKDSLLQRERFIEQEKAKLEQLFQDEVAKAQQLREEQQRQQQQMEQERQRLVASMEEARRRQHEAEEGVRRKQEELQQLEQQRRQQEELLAEENQRLREQLQLLEEQHRAALAHSEEVTASQVAATKTLPNGRDALDGPAAEAEPEHSFDGLRRKVSAQRLQEAGILSAEELQRLAQGHTTVDELARREDVRHYLQGRSSIAGLLLKATNEKLSVYAALQRQLLSPGTALILLEAQAASGFLLDPVRNRRLTVNEAVKEGVVGPELHHKLLSAERAVTGYKDPYTGQQISLFQAMQKGLIVREHGIRLLEAQIATGGVIDPVHSHRVPVDVAYRRGYFDEEMNRVLADPSDDTKGFFDPNTHENLTYLQLLERCVEDPETGLCLLPLTDKAAKGGELVYTDSEARDVFEKATVSAPFGKFQGKTVTIWEIINSEYFTAEQRRDLLRQFRTGRITVEKIIKIIITVVEEQEQKGRLCFEGLRSLVPAAELLESRVIDRELYQQLQRGERSVRDVAEVDTVRRALRGANVIAGVWLEEAGQKLSIYNALKKDLLPSDMAVALLEAQAGTGHIIDPATSARLTVDEAVRAGLVGPEFHEKLLSAEKAVTGYRDPYTGQSVSLFQALKKGLIPREQGLRLLDAQLSTGGIVDPSKSHRVPLDVACARGCLDEETSRALSAPRADAKAYSDPSTGEPATYGELQQRCRPDQLTGLSLLPLSEKAARARQEELYSELQARETFEKTPVEVPVGGFKGRTVTVWELISSEYFTAEQRQELLRQFRTGKVTVEKVIKILITIVEEVETLRQERLSFSGLRAPVPASELLASGVLSRAQFEQLKDGKTTVKDLSELGSVRTLLQGSGCLAGIYLEDTKEKVSIYEAMRRGLLRATTAALLLEAQAATGFLVDPVRNQRLYVHEAVKAGVVGPELHEQLLSAEKAVTGYRDPYSGSTISLFQAMQKGLVLRQHGIRLLEAQIATGGIIDPVHSHRVPVDVAYQRGYFSEEMNRVLADPSDDTKGFFDPNTHENLTYRQLLERCVEDPETGLRLLPLKGAEKAEVVETTQVYTEEETRRAFEETQIDIPGGGSHGGSTMSLWEVMQSDLIPEEQRAQLMADFQAGRVTKERMIIIIIEIIEKTEIIRQQGLASYDYVRRRLTAEDLFEARIISLETYNLLREGTRSLREALEAESAWCYLYGTGSVAGVYLPGSRQTLSIYQALKKGLLSAEVARLLLEAQAATGFLLDPVKGERLTVDEAVRKGLVGPELHDRLLSAERAVTGYRDPYTEQTISLFQAMKKELIPTEEALRLLDAQLATGGIVDPRLGFHLPLEVAYQRGYLNKDTHDQLSEPSEVRSYVDPSTDERLSYTQLLRRCRRDDGTGQLLLPLSDARKLTFRGLRKQITMEELVRSQVMDEATALQLREGLTSIEEVTKNLQKFLEGTSCIAGVFVDATKERLSVYQAMKKGIIRPGTAFELLEAQAATGYVIDPIKGLKLTVEEAVRMGIVGPEFKDKLLSAERAVTGYKDPYSGKLISLFQAMKKGLILKDHGIRLLEAQIATGGIIDPEESHRLPVEVAYKRGLFDEEMNEILTDPSDDTKGFFDPNTEENLTYLQLMERCITDPQTGLCLLPLKEKKRERKTSSKSSVRKRRVVIVDPETGKEMSVYEAYRKGLIDHQTYLELSEQECEWEEITISSSDGVVKSMIIDRRSGRQYDIDDAIAKNLIDRSALDQYRAGTLSITEFADMLSGNAGGFRSRSSSVGSSSSYPISPAVSRTQLASWSDPTEETGPVAGILDTETLEKVSITEAMHRNLVDNITGQRLLEAQACTGGIIDPSTGERFPVTDAVNKGLVDKIMVDRINLAQKAFCGFEDPRTKTKMSAAQALKKGWLYYEAGQRFLEVQYLTGGLIEPDTPGRVPLDEALQRGTVDARTAQKLRDVGAYSKYLTCPKTKLKISYKDALDRSMVEEGTGLRLLEAAAQSTKGYYSPYSVSGSGSTAGSRTGSRTGSRAGSRRGSFDATGSGFSMTFSSSSYSSSGYGRRYASGSSASLGGPESAVA</ns0:Seq>
+      <ns0:cvParam accession="MS:1001088" name="protein description" cvRef="PSI-MS" value="&gt;IPI:IPI00398776.3|TREMBL:Q6S379;Q96IE3|REFSEQ:NP_958783 Tax_Id=9606 plectin 1 isoform 7"/>
+    </ns0:DBSequence>
+    <ns0:DBSequence id="prot6_IPI" accession="IPI00554788.5" searchDatabase_ref="ipi.HUMAN_decoy">
+      <ns0:Seq>MSFTTRSTFSTNYRSLGSVQAPSYGARPVSSAASVYAGAGGSGSRISVSRSTSFRGGMGSGGLATGIAGGLAGMGGIQNEKETMQSLNDRLASYLDRVRSLETENRRLESKIREHLEKKGPQVRDWSHYFKIIEDLRAQIFANTVDNARIVLQIDNARLAADDFRVKYETELAMRQSVENDIHGLRKVIDDTNITRLQLETEIEALKEELLFMKKNHEEEVKGLQAQIASSGLTVEVDAPKSQDLAKIMADIRAQYDELARKNREELDKYWSQQIEESTTVVTTQSAEVGAAETTLTELRRTVQSLEIDLDSMRNLKASLENSLREVEARYALQMEQLNGILLHLESELAQTRAEGQRQAQEYEALLNIKVKLEAEIATYRRLLEDGEDFNLGDALDSSNSMQTIQKTTTRRIVDGKVVSETNDTKVLRH</ns0:Seq>
+      <ns0:cvParam accession="MS:1001088" name="protein description" cvRef="PSI-MS" value="&gt;IPI:IPI00554788.5|SWISS-PROT:P05783|ENSEMBL:ENSP00000373487;ENSP00000373489|REFSEQ:NP_000215;NP_954657|H-INV:HIT000280941|VEGA:OTTHUMP00000167632 Tax_Id=9606 Gene_Symbol=KRT18 Keratin, type I cytoskeletal 18"/>
+    </ns0:DBSequence>
+    <ns0:DBSequence id="prot7_SHD" accession="SHD00644576.1" searchDatabase_ref="ipi.HUMAN_decoy">
+      <ns0:Seq>PSKYTHAFFHGGTVLFTYVDGLIAESLQLVTQSPPAAGVAGMYDGTSPTTTDIADFEGGPVKEDDEQKLLSSCPRVKGSEPKSPDHGACPSKGLNCKEAHAACCAVFYDYGVEVELVSALSATGAVVHKTASCTLDVTYPEDTIDGDPTAGRKTKKCKGSKATPPDYVRGEKVEIAARGPNDKLYYFEVVSREKPLGAFKCGNQKVNIVYEGVVVVGELEAKILDEVQGTTDGVVGSKDTTQINVIVFNLPCKTGSFVCNRAYKCDKPMDAEGPVVAKLNPGRAALVLHHPEQDKGLNLTGGVHNDTPDGVQKGLDITPTSVAPPMKQQVHNVVMRKKDTLDSKAQIATPETAFVNADAEPVSPWSELIVSEKLGENALGTLQPFHQAVDTTVAKPYRAPLAPWGAVVVNEQFVPAVSVNIGAERESEYILQTAGKCIADDLEGITETNKAVTTREDGPSISYIPSGGDAVSYDTQNRVGTTSLSPWKVDRGVSLSVGALKLLRIVWNDFCADTPVCVAGEVSYSTVGRGVSAGVAAPNPPVKAMVSRPIGTVSRIGGSDTRAGMKFSMHTGGIHTTKSKDDGESGSSYGGDTTVIEYGVEGGSTTVQELAIAPVGAYNLSAQPFGVKGRNEETKKTYSFQVAFVFGVLIFPESPRSREIQNPPAPIVYFVKSGDAQDKGGKEKAGTALIPFMVDPASGLKMYGPMGTRNQNDLGQESQGGTPSKTSEDDVSYNETKQLRATGGAGEETSDADSPKRLSEHGASASPMVQMGIGVINLEYGAPSVTPTVEPCRVTEYVSSSDSEGYAGTRVSAGVDQIDVKPLITLQIYPRSLYQVQENKCLATQAAIVYSSADVVPVVVLNKSGHGKFKVDRTDRKQHEVHYGNKCDDTNGDKNIGGNPSTVLESKDCCGISCVPLKVKTGKGVGPVTMSPPMGPAVHGGDIVHSLREVVVVSAVGKSDVVRGAGVAESKVISKRVAVTMADFSYVEKGIGRKGFSETDFGHKGPGDGRVVGSSRKVSSFFVIFQPAGGWKVIEVILHDAIIGGDGQIGGTANPFVGYTLKEASGVDYADVPVIGVLAYYVAELYRDQHGTDQGPGPEGNEITADPGVGTGAEDGRASGYGAGIVTTKTTDSTGCPHRPVQAERLGRKLRSEPVMGVKPGVGGTHCNEDINEKTGIALDVVRAPPAFQPSISGVHTKSSATDVGPDVFDTGGVALVCQPVVGSVVSPYYCPPFGAGVIECYPMSTDPADSSRRNFKPPQRVVTTTEAGDDSGAYVYRYFGPGADMKLPKDSSDVVGNGDCESDPPKLSGNVPQHPEQYSTPAESMRGDPAVSDSLVMANVEFPKCEPDQNYGGHDGKVAPFFDRENEQVDVGLPNDSKGPCVRGVFPLFHYIGSVAPRAVIKCPTTLGPIGQTGGFPGFKSIAYLLIGTGCFQKLLKYVITELVDNCDGCRAKYGSDSTGSFVMEAKGLPIQGFKGKSGTDKCNHEKVDIELTTSGKRPRPPANQAKIEDVLPNAVTDVKECTAVYVDREIELDEIDPHTAQGHRYKRGPKEPIAWSIELSPSGRYMVELLVEISVAFVPPIPIFGTEVAPVGAPAISTSGSPGPAIGRVTLGQKAALPTEPEPSNSYARVDRQEEKRTPEGCGEAAKAHHPPFGINPLAQVIEDQDAYHFDHVGARIGLERGTSCDGESEAIEGPVLYAAPAKAAPSGEVHIARQDVKDPLAGGELHTVLDRCDAVSYESSKSQPLHTITFSKPEPGKSDAMITPPVIEPIVFIWIQRAHFPNGETSLGSSRAFAGKRVSKTYGGSDLRECWIGGGPKKNLKPCQPGEGTGKPITGEPLGMVIVRTLPRWELVKHFLVAPGTVIGTTGHADHVSRPGKPVLIPTERANWPVPRHYTELHDGREVKCTREGVKFHRLDTVNAAVHKNYRHPSSKSSCLWHGVVTKEQAGQISIREFVEDVSPGSIIVDIVNLVAVQGPSSTGSGLGVVHAYPLTYYTVKDIVVALKLSSASFIMVNKKAVVTVCFSDVQSGFKKNVASPPGVLSVSIGLDTYEGDPGIATNWWPSTDEKPCGNVLEDSGPDENHSNPNTAWEFTGLGDTKEGRPNTAFVESEMVLLPVAYVLEQKHPGQGQVGNTMLKDGICEGSTSHVGAVDPSEVQPLGFPGRLITKKFLETFIFCYPSEPIGKGKKVDGKLTSSYSSELAERELVLALAVGIGDAVYYYAFGAGPKIHVFTGDGGGVKNGILVLEGPFHGDEPDLGPFNPGPTQGVERGYSGGEKLATPTVTTYVPELVGLVVVGGTDGIGVHAAVVERWGTYDGKVSPQSVYTTKPGPLSGSDDIHLNVKTVKYLHDEGYTFTIPPHGEKVVEVVEAEQVGRQSDGTTYVTQNNAQAIPVKLRRTAPYGELGHVKLDQVGEEYFGIKFHVNGCDGPGTGPENATYVEQTSGVPPRTPVFGFSVEGTLIQSPQIALNKGRHAVTTIIKQARPFLGGVKGTTDQTPDAFVPHKQTEPLVAACKYVGGWYNHVVPKGKAGEGQGQHRPAVKRANPSDEQAMQSMKKPSPPTPQGEEVSTSVKDLEPESYFQQNVYVNVPAHIGKKLPGIECNQND</ns0:Seq>
+      <ns0:cvParam accession="MS:1001088" name="protein description" cvRef="PSI-MS" value="&gt;SHD:SHD00644576.1|TREMBL:Q5HY54;Q86TQ3;Q96C61|ENSEMBL:ENSP00000358863|VEGA:OTTHUMP00000064890 Tax_Id=9606 Gene_Symbol=FLNA Filamin A, alpha"/>
+    </ns0:DBSequence>
+    <ns0:Peptide id="prot1_pep1">
+      <ns0:PeptideSequence>AGTQIENIDEDFR</ns0:PeptideSequence>
+    </ns0:Peptide>
+    <ns0:Peptide id="prot1_pep2">
+      <ns0:PeptideSequence>AGTQIENIDEDFRDGLK</ns0:PeptideSequence>
+    </ns0:Peptide>
+    <ns0:Peptide id="prot1_pep3">
+      <ns0:PeptideSequence>ALDFIASK</ns0:PeptideSequence>
+    </ns0:Peptide>
+    <ns0:Peptide id="prot1_pep4">
+      <ns0:PeptideSequence>MLDAEDIVNTARPDEK</ns0:PeptideSequence>
+      <ns0:Modification location="1">
+        <ns0:cvParam accession="UNIMOD:35" name="Oxidation" cvRef="UNIMOD"/>
+      </ns0:Modification>
+    </ns0:Peptide>
+    <ns0:Peptide id="prot2_pep1">
+      <!-- identified in two spectra with different scores! -->
+      <ns0:PeptideSequence>SYTSGPGSR</ns0:PeptideSequence>
+    </ns0:Peptide>
+    <ns0:Peptide id="prot2_pep2">
+      <ns0:PeptideSequence>GGLGGGYGGASGMGGITAVTVNQSLLSPLVLEVDPNIQAVR</ns0:PeptideSequence>
+      <ns0:Modification location="13">
+        <ns0:cvParam accession="UNIMOD:35" name="Oxidation" cvRef="UNIMOD"/>
+      </ns0:Modification>
+    </ns0:Peptide>
+    <ns0:Peptide id="prot3_pep1">
+      <ns0:PeptideSequence>TLTLVDTGIGMTK</ns0:PeptideSequence>
+      <ns0:Modification location="11">
+        <ns0:cvParam accession="UNIMOD:35" name="Oxidation" cvRef="UNIMOD"/>
+      </ns0:Modification>
+    </ns0:Peptide>
+    <ns0:Peptide id="prot3_pep2">
+      <ns0:PeptideSequence>HNDDEQYAWESSAGGSFTVR</ns0:PeptideSequence>
+    </ns0:Peptide>
+    <ns0:Peptide id="prot3_pep3">
+      <ns0:PeptideSequence>YHTSQSGDEMTSLSEYVSR</ns0:PeptideSequence>
+      <ns0:Modification location="10">
+        <ns0:cvParam accession="UNIMOD:35" name="Oxidation" cvRef="UNIMOD"/>
+      </ns0:Modification>
+    </ns0:Peptide>
+    <ns0:Peptide id="prot4_pep1">
+      <ns0:PeptideSequence>ENDILKMPIAAVR</ns0:PeptideSequence>
+    </ns0:Peptide>
+    <ns0:Peptide id="prot4_pep2">
+      <ns0:PeptideSequence>LLEDDFSMKK</ns0:PeptideSequence>
+    </ns0:Peptide>
+    <ns0:Peptide id="prot5_pep1">
+      <ns0:PeptideSequence>DGHNLISLLEVLSGDSLPR</ns0:PeptideSequence>
+    </ns0:Peptide>
+    <ns0:Peptide id="prot5_pep2">
+      <ns0:PeptideSequence>QTNLENLDQAFSVAER</ns0:PeptideSequence>
+    </ns0:Peptide>
+    <ns0:Peptide id="prot5_pep3">
+      <ns0:PeptideSequence>HHTAAFEER</ns0:PeptideSequence>
+    </ns0:Peptide>
+    <ns0:Peptide id="prot6_pep1">
+      <ns0:PeptideSequence>STFSTNYR</ns0:PeptideSequence>
+    </ns0:Peptide>
+    <ns0:Peptide id="prot6_pep2">
+      <ns0:PeptideSequence>GGMGSGGLATGIAGGLAGMGGIQNEK</ns0:PeptideSequence>
+    </ns0:Peptide>
+    <ns0:Peptide id="prot7_pep1">
+      <ns0:PeptideSequence>MYGPMGTR</ns0:PeptideSequence>
+    </ns0:Peptide>
+    <ns0:Peptide id="prot7_pep2">
+      <ns0:PeptideSequence>LRSEPVMGVK</ns0:PeptideSequence>
+    </ns0:Peptide>
+    <ns0:Peptide id="prot7_pep3">
+      <ns0:PeptideSequence>QSDGTTYVTQNNAQAIPVK</ns0:PeptideSequence>
+    </ns0:Peptide>
+    <ns0:PeptideEvidence id="PE1_SEQ_spec1_pep1" peptide_ref="prot1_pep1" start="67" end="79" pre="K" post="D" isDecoy="false" dBSequence_ref="prot1_IPI"/>
+    <ns0:PeptideEvidence id="PE1_SEQ_spec2a_pep1" peptide_ref="prot1_pep2" start="67" end="83" pre="K" post="L" isDecoy="false" dBSequence_ref="prot1_IPI"/>
+    <ns0:PeptideEvidence id="PE1_SEQ_spec3a_pep1" peptide_ref="prot1_pep3" start="115" end="122" pre="K" post="G" isDecoy="false" dBSequence_ref="prot1_IPI"/>
+    <ns0:PeptideEvidence id="PE1_SEQ_spec10_pep1" peptide_ref="prot1_pep4" start="240" end="255" pre="K" post="A" isDecoy="false" dBSequence_ref="prot1_IPI"/>
+    <ns0:PeptideEvidence id="PE1_SEQ_spec11a_pep1" peptide_ref="prot2_pep1" start="23" end="31" pre="R" post="I" isDecoy="false" dBSequence_ref="prot2_IPI"/>
+    <ns0:PeptideEvidence id="PE1_SEQ_spec11a_pep2" peptide_ref="prot3_pep1" start="82" end="94" pre="R" post="A" isDecoy="false" dBSequence_ref="prot3_IPI"/>
+    <ns0:PeptideEvidence id="PE1_SEQ_spec12_pep1" peptide_ref="prot3_pep2" start="148" end="167" pre="K" post="A" isDecoy="false" dBSequence_ref="prot3_IPI"/>
+    <ns0:PeptideEvidence id="PE1_SEQ_spec12_pep2" peptide_ref="prot2_pep2" start="47" end="87" pre="R" post="T" isDecoy="false" dBSequence_ref="prot2_IPI"/>
+    <ns0:PeptideEvidence id="PE1_SEQ_spec13_pep1" peptide_ref="prot2_pep1" start="23" end="31" pre="R" post="I" isDecoy="false" dBSequence_ref="prot2_IPI"/>
+    <ns0:PeptideEvidence id="PE1_SEQ_spec13_pep2" peptide_ref="prot3_pep3" start="456" end="474" pre="R" post="M" isDecoy="false" dBSequence_ref="prot3_IPI"/>
+    <ns0:PeptideEvidence id="PE1_SEQ_spec15_pep1" peptide_ref="prot4_pep1" start="183" end="191" pre="L" post="V" isDecoy="true" dBSequence_ref="prot4_SHD"/>
+    <ns0:PeptideEvidence id="PE1_SEQ_spec20_pep1" peptide_ref="prot4_pep2" start="223" end="234" pre="R" post="K" isDecoy="true" dBSequence_ref="prot4_SHD"/>
+    <ns0:PeptideEvidence id="PE1_Mas_spec2b_pep1" peptide_ref="prot5_pep1" start="40" end="59" pre="R" post="E" isDecoy="false" dBSequence_ref="prot5_IPI"/>
+    <ns0:PeptideEvidence id="PE1_Mas_spec3b_pep1" peptide_ref="prot5_pep2" start="181" end="197" pre="R" post="D" isDecoy="false" dBSequence_ref="prot5_IPI"/>
+    <ns0:PeptideEvidence id="PE1_Mas_spec4_pep1" peptide_ref="prot5_pep3" start="265" end="274" pre="R" post="R" isDecoy="false" dBSequence_ref="prot5_IPI"/>
+    <ns0:PeptideEvidence id="PE1_Mas_spec6_pep1" peptide_ref="prot6_pep1" start="7" end="15" pre="R" post="S" isDecoy="false" dBSequence_ref="prot6_IPI"/>
+    <ns0:PeptideEvidence id="PE1_Mas_spec6_pep2" peptide_ref="prot7_pep1" start="702" end="710" pre="K" post="N" isDecoy="true" dBSequence_ref="prot7_SHD"/>
+    <ns0:PeptideEvidence id="PE1_Mas_spec11b_pep1" peptide_ref="prot3_pep1" start="41" end="50" pre="R" post="A" isDecoy="false" dBSequence_ref="prot3_IPI"/>
+    <ns0:PeptideEvidence id="PE1_Mas_spec12_pep1" peptide_ref="prot3_pep2" start="41" end="50" pre="K" post="A" isDecoy="false" dBSequence_ref="prot3_IPI"/>
+    <ns0:PeptideEvidence id="PE1_Mas_spec35_pep1" peptide_ref="prot6_pep2" start="55" end="81" pre="R" post="E" isDecoy="false" dBSequence_ref="prot6_IPI"/>
+    <ns0:PeptideEvidence id="PE1_Mas_spec36b1_pep1" peptide_ref="prot7_pep2" start="1150" end="1159" pre="K" post="P" isDecoy="true" dBSequence_ref="prot7_SHD"/>
+    <ns0:PeptideEvidence id="PE1_Mas_spec40_pep1" peptide_ref="prot7_pep3" start="2378" end="2397" pre="R" post="L" isDecoy="true" dBSequence_ref="prot7_SHD"/>
+  </ns0:SequenceCollection>
+  <ns0:AnalysisCollection>
+    <ns0:SpectrumIdentification id="SEQUEST_analysis" spectrumIdentificationProtocol_ref="SEQUEST_proto" spectrumIdentificationList_ref="SEQUEST_results" activityDate="2007-05-12T13:00:00">
+      <ns0:InputSpectra spectraData_ref="LCMALDI_spectra"/>
+      <ns0:SearchDatabaseRef searchDatabase_ref="ipi.HUMAN_decoy"/>
+    </ns0:SpectrumIdentification>
+    <ns0:SpectrumIdentification id="Mascot_analysis" spectrumIdentificationProtocol_ref="Mascot_proto" spectrumIdentificationList_ref="Mascot_results" activityDate="2007-05-12T14:00:00">
+      <ns0:InputSpectra spectraData_ref="LCMALDI_spectra"/>
+      <ns0:SearchDatabaseRef searchDatabase_ref="ipi.HUMAN_decoy"/>
+    </ns0:SpectrumIdentification>
+    <ns0:ProteinDetection id="ProteinExtractor_analysis" proteinDetectionProtocol_ref="ProteinExtractor_proto" proteinDetectionList_ref="ProteinExtractor_results" activityDate="2007-05-12T15:30:00">
+      <ns0:InputSpectrumIdentifications spectrumIdentificationList_ref="SEQUEST_results"/>
+      <ns0:InputSpectrumIdentifications spectrumIdentificationList_ref="Mascot_results"/>
+    </ns0:ProteinDetection>
+  </ns0:AnalysisCollection>
+  <ns0:AnalysisProtocolCollection>
+    <ns0:SpectrumIdentificationProtocol id="SEQUEST_proto" analysisSoftware_ref="SEQUEST_SW">
+      <ns0:SearchType>
+        <ns0:cvParam accession="MS:1001083" name="ms-ms search" cvRef="PSI-MS"/>
+      </ns0:SearchType>
+      <ns0:AdditionalSearchParams>
+        <ns0:cvParam accession="MS:1001211" name="parent mass type mono" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001256" name="fragment mass type mono" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001259" name="param: immonium ion" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001108" name="param: a ion" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001146" name="param: a ion-NH3" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001148" name="param: a ion-H2O" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001118" name="param: b ion" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001149" name="param: b ion-NH3" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001150" name="param: b ion-H2O" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001262" name="param: y ion" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001151" name="param: y ion-NH3" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001152" name="param: y ion-H2O" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001406" name="param: internal yb ion" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001407" name="param: internal ya ion" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001258" name="param: d ion" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001257" name="param: v ion" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001260" name="param: w ion" cvRef="PSI-MS"/>
+      </ns0:AdditionalSearchParams>
+      <ns0:ModificationParams>
+        <ns0:SearchModification fixedMod="false" massDelta="15.994914622" residues="M">
+          <ns0:cvParam accession="UNIMOD:35" name="Oxidation" cvRef="UNIMOD"/>
+        </ns0:SearchModification>
+      </ns0:ModificationParams>
+      <ns0:Enzymes>
+        <ns0:Enzyme id="Trypsin_SEQUEST_proto">
+          <ns0:EnzymeName>
+            <ns0:cvParam accession="MS:1001251" name="Trypsin" cvRef="PSI-MS"/>
+          </ns0:EnzymeName>
+        </ns0:Enzyme>
+      </ns0:Enzymes>
+      <ns0:FragmentTolerance>
+        <ns0:cvParam accession="MS:1001412" name="search tolerance plus value" cvRef="PSI-MS" value="0.9" unitAccession="UO:0000221" unitName="dalton" unitCvRef="UO"/>
+        <ns0:cvParam accession="MS:1001413" name="search tolerance minus value" cvRef="PSI-MS" value="0.9" unitAccession="UO:0000221" unitName="dalton" unitCvRef="UO"/>
+      </ns0:FragmentTolerance>
+      <ns0:ParentTolerance>
+        <ns0:cvParam accession="MS:1001412" name="search tolerance plus value" cvRef="PSI-MS" value="75.0" unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO"/>
+        <ns0:cvParam accession="MS:1001413" name="search tolerance minus value" cvRef="PSI-MS" value="75.0" unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO"/>
+      </ns0:ParentTolerance>
+      <ns0:Threshold>
+        <ns0:cvParam accession="MS:1001494" name="no threshold" cvRef="PSI-MS"/>
+      </ns0:Threshold>
+    </ns0:SpectrumIdentificationProtocol>
+    <ns0:SpectrumIdentificationProtocol id="Mascot_proto" analysisSoftware_ref="Mascot_SW">
+      <ns0:SearchType>
+        <ns0:cvParam accession="MS:1001083" name="ms-ms search" cvRef="PSI-MS"/>
+      </ns0:SearchType>
+      <ns0:AdditionalSearchParams>
+        <ns0:cvParam accession="MS:1001211" name="parent mass type mono" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001256" name="fragment mass type mono" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001259" name="param: immonium ion" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001108" name="param: a ion" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001146" name="param: a ion-NH3" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001148" name="param: a ion-H2O" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001118" name="param: b ion" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001149" name="param: b ion-NH3" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001150" name="param: b ion-H2O" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001262" name="param: y ion" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001151" name="param: y ion-NH3" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001152" name="param: y ion-H2O" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001406" name="param: internal yb ion" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001407" name="param: internal ya ion" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001258" name="param: d ion" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001257" name="param: v ion" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001260" name="param: w ion" cvRef="PSI-MS"/>
+      </ns0:AdditionalSearchParams>
+      <ns0:ModificationParams>
+        <ns0:SearchModification fixedMod="false" residues="M" massDelta="15.994914622">
+          <ns0:cvParam accession="UNIMOD:35" name="Oxidation" cvRef="UNIMOD"/>
+        </ns0:SearchModification>
+      </ns0:ModificationParams>
+      <ns0:Enzymes>
+        <ns0:Enzyme id="Trypsin_Mascot_proto">
+          <ns0:EnzymeName>
+            <ns0:cvParam accession="MS:1001251" name="Trypsin" cvRef="PSI-MS"/>
+          </ns0:EnzymeName>
+        </ns0:Enzyme>
+      </ns0:Enzymes>
+      <ns0:FragmentTolerance>
+        <ns0:cvParam accession="MS:1001412" name="search tolerance plus value" cvRef="PSI-MS" value="0.9" unitAccession="UO:0000221" unitName="dalton" unitCvRef="UO"/>
+        <ns0:cvParam accession="MS:1001413" name="search tolerance minus value" cvRef="PSI-MS" value="0.9" unitAccession="UO:0000221" unitName="dalton" unitCvRef="UO"/>
+      </ns0:FragmentTolerance>
+      <ns0:ParentTolerance>
+        <ns0:cvParam accession="MS:1001412" name="search tolerance plus value" cvRef="PSI-MS" value="75.0" unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO"/>
+        <ns0:cvParam accession="MS:1001413" name="search tolerance minus value" cvRef="PSI-MS" value="75.0" unitAccession="UO:0000169" unitName="parts per million" unitCvRef="UO"/>
+      </ns0:ParentTolerance>
+      <ns0:Threshold>
+        <ns0:cvParam accession="MS:1001494" name="no threshold" cvRef="PSI-MS"/>
+      </ns0:Threshold>
+    </ns0:SpectrumIdentificationProtocol>
+    <ns0:ProteinDetectionProtocol id="ProteinExtractor_proto" analysisSoftware_ref="ProteinExtractor_SW">
+      <ns0:AnalysisParams>
+        <ns0:cvParam accession="MS:1001424" name="ProteinExtractor:Methodname" cvRef="PSI-MS" value="SEQUEST_2.5"/>
+        <ns0:cvParam accession="MS:1001425" name="ProteinExtractor:GenerateNonRedundant" cvRef="PSI-MS" value="true"/>
+        <ns0:cvParam accession="MS:1001426" name="ProteinExtractor:IncludeIdentified" cvRef="PSI-MS" value="false"/>
+        <ns0:cvParam accession="MS:1001427" name="ProteinExtractor:MaxNumberOfProteins" cvRef="PSI-MS" value="3000"/>
+        <ns0:cvParam accession="MS:1001429" name="ProteinExtractor:MinNumberOfPeptides" cvRef="PSI-MS" value="2"/>
+        <ns0:cvParam accession="MS:1001430" name="ProteinExtractor:UseMascot" cvRef="PSI-MS" value="false"/>
+        <ns0:cvParam accession="MS:1001431" name="ProteinExtractor:MascotPeptideScoreThreshold" cvRef="PSI-MS" value="0.0"/>
+        <ns0:cvParam accession="MS:1001432" name="ProteinExtractor:MascotUniqueScore" cvRef="PSI-MS" value="0.0"/>
+        <ns0:cvParam accession="MS:1001433" name="ProteinExtractor:MascotUseIdentityScore" cvRef="PSI-MS" value="false"/>
+        <ns0:cvParam accession="MS:1001434" name="ProteinExtractor:MascotWeighting" cvRef="PSI-MS" value="0.0"/>
+        <ns0:cvParam accession="MS:1001435" name="ProteinExtractor:UseSequest" cvRef="PSI-MS" value="true"/>
+        <ns0:cvParam accession="MS:1001436" name="ProteinExtractor:SequestPeptideScoreThreshold" cvRef="PSI-MS" value="2.5"/>
+        <ns0:cvParam accession="MS:1001437" name="ProteinExtractor:SequestUniqueScore" cvRef="PSI-MS" value="2.5"/>
+        <ns0:cvParam accession="MS:1001438" name="ProteinExtractor:SequestWeighting" cvRef="PSI-MS" value="1.0"/>
+        <ns0:cvParam accession="MS:1001439" name="ProteinExtractor:UseProteinSolver" cvRef="PSI-MS" value="false"/>
+        <ns0:cvParam accession="MS:1001440" name="ProteinExtractor:ProteinSolverPeptideScoreThreshold" cvRef="PSI-MS" value="0.0"/>
+        <ns0:cvParam accession="MS:1001441" name="ProteinExtractor:ProteinSolverUniqueScore" cvRef="PSI-MS" value="0.0"/>
+        <ns0:cvParam accession="MS:1001442" name="ProteinExtractor:ProteinSolverWeighting" cvRef="PSI-MS" value="0.0"/>
+        <ns0:cvParam accession="MS:1001443" name="ProteinExtractor:UsePhenyx" cvRef="PSI-MS" value="false"/>
+        <ns0:cvParam accession="MS:1001444" name="ProteinExtractor:PhenyxPeptideScoreThreshold" cvRef="PSI-MS" value="0.0"/>
+        <ns0:cvParam accession="MS:1001445" name="ProteinExtractor:PhenyxUniqueScore" cvRef="PSI-MS" value="0.0"/>
+        <ns0:cvParam accession="MS:1001446" name="ProteinExtractor:PhenyxWeighting" cvRef="PSI-MS" value="0.0"/>
+      </ns0:AnalysisParams>
+      <ns0:Threshold>
+        <ns0:cvParam accession="MS:1001447" name="prot:FDR threshold" cvRef="PSI-MS" value="0.05"/>
+      </ns0:Threshold>
+    </ns0:ProteinDetectionProtocol>
+  </ns0:AnalysisProtocolCollection>
+  <ns0:DataCollection>
+    <ns0:Inputs>
+      <ns0:SourceFile id="SF1" location="proteinscape://www.medizinisches-proteom-center.de/PSServer/Project/Sample/Separation_1D_LC/Fraction_X/SpectraData/Results1">
+        <ns0:FileFormat>
+          <ns0:cvParam accession="MS:1001275" name="ProteinScape SearchEvent" cvRef="PSI-MS"/>
+        </ns0:FileFormat>
+      </ns0:SourceFile>
+      <ns0:SearchDatabase id="ipi.HUMAN_decoy" location="file://www.medizinisches-proteom-center.de/DBServer/ipi.HUMAN/3.15/ipi.HUMAN_decoy.fasta" version="3.15" releaseDate="2006-02-22T09:30:47Z" numDatabaseSequences="58099">
+        <ns0:DatabaseName>
+          <ns0:cvParam accession="MS:1001142" name="database IPI_human" cvRef="PSI-MS"/>
+        </ns0:DatabaseName>
+        <ns0:cvParam accession="MS:1001300" name="decoy DB from IPI_human" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001197" name="DB composition target+decoy" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001452" name="decoy DB type shuffle" cvRef="PSI-MS"/>
+        <ns0:cvParam accession="MS:1001451" name="decoy DB generation algorithm" cvRef="PSI-MS" value="PeakQuant.DecoyDatabaseBuilder"/>
+        <ns0:cvParam accession="MS:1001283" name="decoy DB accession regexp" cvRef="PSI-MS" value="^SHD"/>
+      </ns0:SearchDatabase>
+      <ns0:SpectraData id="LCMALDI_spectra" location="proteinscape://www.medizinisches-proteom-center.de/PSServer/Project/Sample/Separation_1D_LC/Fraction_X">
+        <ns0:FileFormat>
+          <ns0:cvParam accession="MS:1001527" name="Proteinscape spectra" cvRef="PSI-MS"/>
+        </ns0:FileFormat>
+        <ns0:SpectrumIDFormat>
+          <ns0:cvParam accession="MS:1001526" name="spectrum from database nativeID format" cvRef="PSI-MS"/>
+        </ns0:SpectrumIDFormat>
+      </ns0:SpectraData>
+    </ns0:Inputs>
+    <ns0:AnalysisData>
+      <ns0:SpectrumIdentificationList id="SEQUEST_results">
+        <ns0:SpectrumIdentificationResult id="SEQ_spec1" spectrumID="databasekey=1" spectraData_ref="LCMALDI_spectra">
+          <ns0:SpectrumIdentificationItem id="SEQ_spec1_pep1" peptide_ref="prot1_pep1" chargeState="1" calculatedMassToCharge="1507.6950" experimentalMassToCharge="1507.696" passThreshold="true" rank="1">
+            <ns0:PeptideEvidenceRef peptideEvidence_ref="PE1_SEQ_spec1_pep1"/>
+            <ns0:cvParam accession="MS:1001505" name="ProteinScape:IntensityCoverage" cvRef="PSI-MS" value="0.3919545603809718"/>
+            <ns0:cvParam accession="MS:1001506" name="ProteinScape:SequestMetaScore" cvRef="PSI-MS" value="7.59488518903425"/>
+          </ns0:SpectrumIdentificationItem>
+        </ns0:SpectrumIdentificationResult>
+        <ns0:SpectrumIdentificationResult id="SEQ_spec2a" spectrumID="databasekey=2" spectraData_ref="LCMALDI_spectra">
+          <ns0:SpectrumIdentificationItem id="SEQ_spec2a_pep1" peptide_ref="prot1_pep2" chargeState="1" calculatedMassToCharge="1920.9224" experimentalMassToCharge="1920.923" passThreshold="true" rank="1">
+            <ns0:PeptideEvidenceRef peptideEvidence_ref="PE1_SEQ_spec2a_pep1"/>
+            <ns0:cvParam accession="MS:1001505" name="ProteinScape:IntensityCoverage" cvRef="PSI-MS" value="0.5070386909133888"/>
+            <ns0:cvParam accession="MS:1001506" name="ProteinScape:SequestMetaScore" cvRef="PSI-MS" value="10.8810331335713"/>
+          </ns0:SpectrumIdentificationItem>
+        </ns0:SpectrumIdentificationResult>
+        <ns0:SpectrumIdentificationResult id="SEQ_spec3a" spectrumID="databasekey=3" spectraData_ref="LCMALDI_spectra">
+          <ns0:SpectrumIdentificationItem id="SEQ_spec3a_pep1" peptide_ref="prot1_pep3" chargeState="1" calculatedMassToCharge="864.4752" experimentalMassToCharge="864.474" passThreshold="true" rank="1">
+            <ns0:PeptideEvidenceRef peptideEvidence_ref="PE1_SEQ_spec3a_pep1"/>
+            <ns0:cvParam accession="MS:1001505" name="ProteinScape:IntensityCoverage" cvRef="PSI-MS" value="0.43376827663349576"/>
+            <ns0:cvParam accession="MS:1001506" name="ProteinScape:SequestMetaScore" cvRef="PSI-MS" value="6.1021771936508955"/>
+          </ns0:SpectrumIdentificationItem>
+        </ns0:SpectrumIdentificationResult>
+        <ns0:SpectrumIdentificationResult id="SEQ_spec10" spectrumID="databasekey=10" spectraData_ref="LCMALDI_spectra">
+          <ns0:SpectrumIdentificationItem id="SEQ_spec10_pep1" peptide_ref="prot1_pep4" chargeState="1" calculatedMassToCharge="1832.862115" experimentalMassToCharge="1832.863" passThreshold="true" rank="1">
+            <ns0:PeptideEvidenceRef peptideEvidence_ref="PE1_SEQ_spec10_pep1"/>
+            <ns0:cvParam accession="MS:1001505" name="ProteinScape:IntensityCoverage" cvRef="PSI-MS" value="0.16164593872706742"/>
+            <ns0:cvParam accession="MS:1001506" name="ProteinScape:SequestMetaScore" cvRef="PSI-MS" value="5.635013787097159"/>
+          </ns0:SpectrumIdentificationItem>
+        </ns0:SpectrumIdentificationResult>
+        <ns0:SpectrumIdentificationResult id="SEQ_spec11a" spectrumID="databasekey=11" spectraData_ref="LCMALDI_spectra">
+          <ns0:SpectrumIdentificationItem id="SEQ_spec11a_pep1" peptide_ref="prot2_pep1" chargeState="1" calculatedMassToCharge="911.4144" experimentalMassToCharge="911.413" passThreshold="true" rank="1">
+            <ns0:PeptideEvidenceRef peptideEvidence_ref="PE1_SEQ_spec11a_pep1"/>
+            <ns0:cvParam accession="MS:1001505" name="ProteinScape:IntensityCoverage" cvRef="PSI-MS" value="0.6146634530945828"/>
+            <ns0:cvParam accession="MS:1001506" name="ProteinScape:SequestMetaScore" cvRef="PSI-MS" value="10.17510605321669"/>
+          </ns0:SpectrumIdentificationItem>
+          <ns0:SpectrumIdentificationItem id="SEQ_spec11a_pep2" peptide_ref="prot3_pep1" chargeState="1" calculatedMassToCharge="1365.722015" experimentalMassToCharge="1365.721" passThreshold="true" rank="2">
+            <ns0:PeptideEvidenceRef peptideEvidence_ref="PE1_SEQ_spec11a_pep2"/>
+            <ns0:cvParam accession="MS:1001505" name="ProteinScape:IntensityCoverage" cvRef="PSI-MS" value="0.2517734933944088"/>
+            <ns0:cvParam accession="MS:1001506" name="ProteinScape:SequestMetaScore" cvRef="PSI-MS" value="6.005532583410669"/>
+          </ns0:SpectrumIdentificationItem>
+        </ns0:SpectrumIdentificationResult>
+        <ns0:SpectrumIdentificationResult id="SEQ_spec12" spectrumID="databasekey=12" spectraData_ref="LCMALDI_spectra">
+          <ns0:SpectrumIdentificationItem id="SEQ_spec12_pep1" peptide_ref="prot3_pep2" chargeState="1" calculatedMassToCharge="2255.9515" experimentalMassToCharge="2255.950" passThreshold="true" rank="1">
+            <ns0:PeptideEvidenceRef peptideEvidence_ref="PE1_SEQ_spec12_pep1"/>
+            <ns0:cvParam accession="MS:1001505" name="ProteinScape:IntensityCoverage" cvRef="PSI-MS" value="0.4884754815768041"/>
+            <ns0:cvParam accession="MS:1001506" name="ProteinScape:SequestMetaScore" cvRef="PSI-MS" value="12.042955809241318"/>
+          </ns0:SpectrumIdentificationItem>
+          <ns0:SpectrumIdentificationItem id="SEQ_spec12_pep2" peptide_ref="prot2_pep2" chargeState="1" calculatedMassToCharge="3941.036315" experimentalMassToCharge="3941.081" passThreshold="true" rank="2">
+            <ns0:PeptideEvidenceRef peptideEvidence_ref="PE1_SEQ_spec12_pep2"/>
+            <ns0:cvParam accession="MS:1001505" name="ProteinScape:IntensityCoverage" cvRef="PSI-MS" value="0.554279316913958"/>
+            <ns0:cvParam accession="MS:1001506" name="ProteinScape:SequestMetaScore" cvRef="PSI-MS" value="3.1184106313104283"/>
+          </ns0:SpectrumIdentificationItem>
+        </ns0:SpectrumIdentificationResult>
+        <ns0:SpectrumIdentificationResult id="SEQ_spec13" spectrumID="databasekey=13" spectraData_ref="LCMALDI_spectra">
+          <ns0:SpectrumIdentificationItem id="SEQ_spec13_pep1" peptide_ref="prot2_pep1" chargeState="1" calculatedMassToCharge="911.4144" experimentalMassToCharge="911.415" passThreshold="true" rank="1">
+            <ns0:PeptideEvidenceRef peptideEvidence_ref="PE1_SEQ_spec13_pep1"/>
+            <ns0:cvParam accession="MS:1001505" name="ProteinScape:IntensityCoverage" cvRef="PSI-MS" value="0.39717937427768873"/>
+            <ns0:cvParam accession="MS:1001506" name="ProteinScape:SequestMetaScore" cvRef="PSI-MS" value="4.159878401845841"/>
+          </ns0:SpectrumIdentificationItem>
+          <ns0:SpectrumIdentificationItem id="SEQ_spec13_pep2" peptide_ref="prot3_pep3" chargeState="1" calculatedMassToCharge="2192.932715" experimentalMassToCharge="2192.90" passThreshold="true" rank="2">
+            <ns0:PeptideEvidenceRef peptideEvidence_ref="PE1_SEQ_spec13_pep2"/>
+            <ns0:cvParam accession="MS:1001505" name="ProteinScape:IntensityCoverage" cvRef="PSI-MS" value="0.136423966822031"/>
+            <ns0:cvParam accession="MS:1001506" name="ProteinScape:SequestMetaScore" cvRef="PSI-MS" value="5.725397508852668"/>
+          </ns0:SpectrumIdentificationItem>
+        </ns0:SpectrumIdentificationResult>
+        <ns0:SpectrumIdentificationResult id="SEQ_spec15" spectrumID="databasekey=15" spectraData_ref="LCMALDI_spectra">
+          <ns0:SpectrumIdentificationItem id="SEQ_spec15_pep1" peptide_ref="prot4_pep1" chargeState="1" calculatedMassToCharge="1469.8071" experimentalMassToCharge="1469.806" passThreshold="true" rank="1">
+            <ns0:PeptideEvidenceRef peptideEvidence_ref="PE1_SEQ_spec15_pep1"/>
+            <ns0:cvParam accession="MS:1001505" name="ProteinScape:IntensityCoverage" cvRef="PSI-MS" value="0.2854129700126088"/>
+            <ns0:cvParam accession="MS:1001506" name="ProteinScape:SequestMetaScore" cvRef="PSI-MS" value="6.181682868401155"/>
+          </ns0:SpectrumIdentificationItem>
+        </ns0:SpectrumIdentificationResult>
+        <ns0:SpectrumIdentificationResult id="SEQ_spec20" spectrumID="databasekey=20" spectraData_ref="LCMALDI_spectra">
+          <ns0:SpectrumIdentificationItem id="SEQ_spec20_pep1" peptide_ref="prot4_pep2" chargeState="1" calculatedMassToCharge="1225.6059" experimentalMassToCharge="1225.604" passThreshold="true" rank="1">
+            <ns0:PeptideEvidenceRef peptideEvidence_ref="PE1_SEQ_spec20_pep1"/>
+            <ns0:cvParam accession="MS:1001505" name="ProteinScape:IntensityCoverage" cvRef="PSI-MS" value="0.29049959198538566"/>
+            <ns0:cvParam accession="MS:1001506" name="ProteinScape:SequestMetaScore" cvRef="PSI-MS" value="6.669916225794168"/>
+          </ns0:SpectrumIdentificationItem>
+        </ns0:SpectrumIdentificationResult>
+      </ns0:SpectrumIdentificationList>
+      <ns0:SpectrumIdentificationList id="Mascot_results">
+        <ns0:SpectrumIdentificationResult id="Mas_spec2b" spectrumID="databasekey=2" spectraData_ref="LCMALDI_spectra">
+          <ns0:SpectrumIdentificationItem id="Mas_spec2b_pep1" peptide_ref="prot5_pep1" chargeState="1" calculatedMassToCharge="2035.0745" experimentalMassToCharge="2035.075" passThreshold="true" rank="1">
+            <ns0:PeptideEvidenceRef peptideEvidence_ref="PE1_Mas_spec2b_pep1"/>
+          </ns0:SpectrumIdentificationItem>
+        </ns0:SpectrumIdentificationResult>
+        <ns0:SpectrumIdentificationResult id="Mas_spec3b" spectrumID="databasekey=3" spectraData_ref="LCMALDI_spectra">
+          <ns0:SpectrumIdentificationItem id="Mas_spec3b_pep1" peptide_ref="prot5_pep2" chargeState="1" calculatedMassToCharge="1834.8856" experimentalMassToCharge="1834.884" passThreshold="true" rank="1">
+            <ns0:PeptideEvidenceRef peptideEvidence_ref="PE1_Mas_spec3b_pep1"/>
+          </ns0:SpectrumIdentificationItem>
+        </ns0:SpectrumIdentificationResult>
+        <ns0:SpectrumIdentificationResult id="Mas_spec4" spectrumID="databasekey=4" spectraData_ref="LCMALDI_spectra">
+          <ns0:SpectrumIdentificationItem id="Mas_spec4_pep1" peptide_ref="prot5_pep3" chargeState="1" calculatedMassToCharge="1097.5049" experimentalMassToCharge="1097.503" passThreshold="true" rank="1">
+            <ns0:PeptideEvidenceRef peptideEvidence_ref="PE1_Mas_spec4_pep1"/>
+          </ns0:SpectrumIdentificationItem>
+        </ns0:SpectrumIdentificationResult>
+        <ns0:SpectrumIdentificationResult id="Mas_spec6" spectrumID="databasekey=6" spectraData_ref="LCMALDI_spectra">
+          <ns0:SpectrumIdentificationItem id="Mas_spec6_pep1" peptide_ref="prot6_pep1" chargeState="1" calculatedMassToCharge="975.4457" experimentalMassToCharge="975.446" passThreshold="true" rank="1">
+            <ns0:PeptideEvidenceRef peptideEvidence_ref="PE1_Mas_spec6_pep1"/>
+          </ns0:SpectrumIdentificationItem>
+          <ns0:SpectrumIdentificationItem id="Mas_spec6_pep2" peptide_ref="prot7_pep1" chargeState="1" calculatedMassToCharge="912.3993" experimentalMassToCharge="912.29" passThreshold="true" rank="1">
+            <ns0:PeptideEvidenceRef peptideEvidence_ref="PE1_Mas_spec6_pep2"/>
+          </ns0:SpectrumIdentificationItem>
+        </ns0:SpectrumIdentificationResult>
+        <ns0:SpectrumIdentificationResult id="Mas_spec11b" spectrumID="databasekey=11" spectraData_ref="LCMALDI_spectra">
+          <ns0:SpectrumIdentificationItem id="Mas_spec11b_pep1" peptide_ref="prot3_pep1" chargeState="1" calculatedMassToCharge="1365.722015" experimentalMassToCharge="1365.721" passThreshold="true" rank="1">
+            <ns0:PeptideEvidenceRef peptideEvidence_ref="PE1_Mas_spec11b_pep1"/>
+            <ns0:cvParam accession="MS:1001505" name="ProteinScape:IntensityCoverage" cvRef="PSI-MS" value="0.0"/>
+            <ns0:userParam name="ProteinScape:MascotScore" value="33.82"/>
+          </ns0:SpectrumIdentificationItem>
+        </ns0:SpectrumIdentificationResult>
+        <ns0:SpectrumIdentificationResult id="Mas_spec12" spectrumID="databasekey=12" spectraData_ref="LCMALDI_spectra">
+          <ns0:SpectrumIdentificationItem id="Mas_spec12_pep1" peptide_ref="prot3_pep2" chargeState="1" calculatedMassToCharge="2256.9515" experimentalMassToCharge="2256.952" passThreshold="true" rank="1">
+            <ns0:PeptideEvidenceRef peptideEvidence_ref="PE1_Mas_spec12_pep1"/>
+            <ns0:cvParam accession="MS:1001505" name="ProteinScape:IntensityCoverage" cvRef="PSI-MS" value="0.0"/>
+            <ns0:userParam name="ProteinScape:MascotScore" value="39.0"/>
+          </ns0:SpectrumIdentificationItem>
+        </ns0:SpectrumIdentificationResult>
+        <ns0:SpectrumIdentificationResult id="Mas_spec35" spectrumID="databasekey=35" spectraData_ref="LCMALDI_spectra">
+          <ns0:SpectrumIdentificationItem id="Mas_spec35_pep1" peptide_ref="prot6_pep2" chargeState="1" calculatedMassToCharge="2261.0939" experimentalMassToCharge="2261.092" passThreshold="true" rank="1">
+            <ns0:PeptideEvidenceRef peptideEvidence_ref="PE1_Mas_spec35_pep1"/>
+          </ns0:SpectrumIdentificationItem>
+        </ns0:SpectrumIdentificationResult>
+        <ns0:SpectrumIdentificationResult id="Mas_spec36b1" spectrumID="databasekey=36" spectraData_ref="LCMALDI_spectra">
+          <ns0:SpectrumIdentificationItem id="Mas_spec36b1_pep1" peptide_ref="prot7_pep2" chargeState="1" calculatedMassToCharge="1115.6168" experimentalMassToCharge="1115.617" passThreshold="true" rank="1">
+            <ns0:PeptideEvidenceRef peptideEvidence_ref="PE1_Mas_spec36b1_pep1"/>
+          </ns0:SpectrumIdentificationItem>
+        </ns0:SpectrumIdentificationResult>
+        <ns0:SpectrumIdentificationResult id="Mas_spec40" spectrumID="databasekey=40" spectraData_ref="LCMALDI_spectra">
+          <ns0:SpectrumIdentificationItem id="Mas_spec40_pep1" peptide_ref="prot7_pep3" chargeState="1" calculatedMassToCharge="2035.0017" experimentalMassToCharge="2035.002" passThreshold="true" rank="1">
+            <ns0:PeptideEvidenceRef peptideEvidence_ref="PE1_Mas_spec40_pep1"/>
+          </ns0:SpectrumIdentificationItem>
+        </ns0:SpectrumIdentificationResult>
+      </ns0:SpectrumIdentificationList>
+      <ns0:ProteinDetectionList id="ProteinExtractor_results">
+        <ns0:ProteinAmbiguityGroup id="group1">
+          <ns0:ProteinDetectionHypothesis id="id_prot1" passThreshold="true" dBSequence_ref="prot1_IPI">
+            <ns0:PeptideHypothesis peptideEvidence_ref="PE1_SEQ_spec1_pep1">
+              <ns0:SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SEQ_spec1_pep1"/>
+            </ns0:PeptideHypothesis>
+            <ns0:PeptideHypothesis peptideEvidence_ref="PE1_SEQ_spec2a_pep1">
+              <ns0:SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SEQ_spec2a_pep1"/>
+            </ns0:PeptideHypothesis>
+            <ns0:PeptideHypothesis peptideEvidence_ref="PE1_SEQ_spec3a_pep1">
+              <ns0:SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SEQ_spec3a_pep1"/>
+            </ns0:PeptideHypothesis>
+            <ns0:PeptideHypothesis peptideEvidence_ref="PE1_SEQ_spec10_pep1">
+              <ns0:SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SEQ_spec10_pep1"/>
+            </ns0:PeptideHypothesis>
+            <ns0:cvParam accession="MS:1001093" name="sequence coverage" cvRef="PSI-MS" value="0.13"/>
+            <ns0:cvParam accession="MS:1001301" name="protein rank" cvRef="PSI-MS" value="1"/>
+            <ns0:cvParam accession="MS:1001097" name="distinct peptide sequences" cvRef="PSI-MS" value="4"/>
+            <ns0:cvParam accession="MS:1001250" name="local FDR" cvRef="PSI-MS" value="0.0" unitAccession="UO:0000187" unitName="percent" unitCvRef="UO"/>
+            <ns0:cvParam accession="MS:1001507" name="ProteinExtractor:Score" cvRef="PSI-MS" value="200.4"/>
+          </ns0:ProteinDetectionHypothesis>
+        </ns0:ProteinAmbiguityGroup>
+        <ns0:ProteinAmbiguityGroup id="group2">
+          <ns0:ProteinDetectionHypothesis id="id_prot2" passThreshold="true">
+            <ns0:PeptideHypothesis peptideEvidence_ref="PE1_SEQ_spec11a_pep1">
+              <ns0:SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SEQ_spec11a_pep1"/>
+            </ns0:PeptideHypothesis>
+            <ns0:PeptideHypothesis peptideEvidence_ref="PE1_SEQ_spec13_pep1">
+              <ns0:SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SEQ_spec13_pep1"/>
+            </ns0:PeptideHypothesis>
+            <ns0:PeptideHypothesis peptideEvidence_ref="PE1_SEQ_spec12_pep2">
+              <ns0:SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SEQ_spec12_pep2"/>
+            </ns0:PeptideHypothesis>
+            <ns0:cvParam accession="MS:1001093" name="sequence coverage" cvRef="PSI-MS" value="0.69"/>
+            <ns0:cvParam accession="MS:1001301" name="protein rank" cvRef="PSI-MS" value="2"/>
+            <ns0:cvParam accession="MS:1001097" name="distinct peptide sequences" cvRef="PSI-MS" value="3"/>
+            <ns0:cvParam accession="MS:1001250" name="local FDR" cvRef="PSI-MS" value="0.0" unitAccession="UO:0000187" unitName="percent" unitCvRef="UO"/>
+            <ns0:cvParam accession="MS:1001507" name="ProteinExtractor:Score" cvRef="PSI-MS" value="150.3"/>
+          </ns0:ProteinDetectionHypothesis>
+        </ns0:ProteinAmbiguityGroup>
+        <ns0:ProteinAmbiguityGroup id="group3">
+          <ns0:ProteinDetectionHypothesis id="id_prot3" passThreshold="false">
+            <ns0:PeptideHypothesis peptideEvidence_ref="PE1_SEQ_spec15_pep1">
+              <ns0:SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SEQ_spec15_pep1"/>
+            </ns0:PeptideHypothesis>
+            <ns0:PeptideHypothesis peptideEvidence_ref="PE1_SEQ_spec20_pep1">
+              <ns0:SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SEQ_spec20_pep1"/>
+            </ns0:PeptideHypothesis>
+            <ns0:cvParam accession="MS:1001093" name="sequence coverage" cvRef="PSI-MS" value="0.59"/>
+            <ns0:cvParam accession="MS:1001301" name="protein rank" cvRef="PSI-MS" value="3"/>
+            <ns0:cvParam accession="MS:1001097" name="distinct peptide sequences" cvRef="PSI-MS" value="2"/>
+            <ns0:cvParam accession="MS:1001250" name="local FDR" cvRef="PSI-MS" value="33.33" unitAccession="UO:0000187" unitName="percent" unitCvRef="UO"/>
+            <ns0:cvParam accession="MS:1001507" name="ProteinExtractor:Score" cvRef="PSI-MS" value="110.2"/>
+          </ns0:ProteinDetectionHypothesis>
+        </ns0:ProteinAmbiguityGroup>
+        <ns0:ProteinAmbiguityGroup id="group4">
+          <ns0:ProteinDetectionHypothesis id="id_prot4" passThreshold="false">
+            <ns0:PeptideHypothesis peptideEvidence_ref="PE1_SEQ_spec11a_pep2">
+              <ns0:SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SEQ_spec11a_pep2"/>
+            </ns0:PeptideHypothesis>
+            <ns0:PeptideHypothesis peptideEvidence_ref="PE1_SEQ_spec12_pep1">
+              <ns0:SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SEQ_spec12_pep1"/>
+            </ns0:PeptideHypothesis>
+            <ns0:PeptideHypothesis peptideEvidence_ref="PE1_SEQ_spec13_pep2">
+              <ns0:SpectrumIdentificationItemRef spectrumIdentificationItem_ref="SEQ_spec13_pep2"/>
+            </ns0:PeptideHypothesis>
+            <ns0:PeptideHypothesis peptideEvidence_ref="PE1_Mas_spec11b_pep1">
+              <ns0:SpectrumIdentificationItemRef spectrumIdentificationItem_ref="Mas_spec11b_pep1"/>
+            </ns0:PeptideHypothesis>
+            <ns0:PeptideHypothesis peptideEvidence_ref="PE1_Mas_spec12_pep1">
+              <ns0:SpectrumIdentificationItemRef spectrumIdentificationItem_ref="Mas_spec12_pep1"/>
+            </ns0:PeptideHypothesis>
+            <ns0:cvParam accession="MS:1001093" name="sequence coverage" cvRef="PSI-MS" value="0.34"/>
+            <ns0:cvParam accession="MS:1001301" name="protein rank" cvRef="PSI-MS" value="4"/>
+            <ns0:cvParam accession="MS:1001097" name="distinct peptide sequences" cvRef="PSI-MS" value="4"/>
+            <ns0:cvParam accession="MS:1001250" name="local FDR" cvRef="PSI-MS" value="25.0" unitAccession="UO:0000187" unitName="percent" unitCvRef="UO"/>
+            <ns0:cvParam accession="MS:1001507" name="ProteinExtractor:Score" cvRef="PSI-MS" value="50.7"/>
+          </ns0:ProteinDetectionHypothesis>
+        </ns0:ProteinAmbiguityGroup>
+        <ns0:ProteinAmbiguityGroup id="group5">
+          <ns0:ProteinDetectionHypothesis id="id_prot5" passThreshold="false">
+            <ns0:PeptideHypothesis peptideEvidence_ref="PE1_Mas_spec2b_pep1">
+              <ns0:SpectrumIdentificationItemRef spectrumIdentificationItem_ref="Mas_spec2b_pep1"/>
+            </ns0:PeptideHypothesis>
+            <ns0:PeptideHypothesis peptideEvidence_ref="PE1_Mas_spec3b_pep1">
+              <ns0:SpectrumIdentificationItemRef spectrumIdentificationItem_ref="Mas_spec3b_pep1"/>
+            </ns0:PeptideHypothesis>
+            <ns0:PeptideHypothesis peptideEvidence_ref="PE1_Mas_spec4_pep1">
+              <ns0:SpectrumIdentificationItemRef spectrumIdentificationItem_ref="Mas_spec4_pep1"/>
+            </ns0:PeptideHypothesis>
+            <ns0:cvParam accession="MS:1001093" name="sequence coverage" cvRef="PSI-MS" value="0.50"/>
+            <ns0:cvParam accession="MS:1001301" name="protein rank" cvRef="PSI-MS" value="5"/>
+            <ns0:cvParam accession="MS:1001097" name="distinct peptide sequences" cvRef="PSI-MS" value="3"/>
+            <ns0:cvParam accession="MS:1001250" name="local FDR" cvRef="PSI-MS" value="20.0" unitAccession="UO:0000187" unitName="percent" unitCvRef="UO"/>
+            <ns0:cvParam accession="MS:1001507" name="ProteinExtractor:Score" cvRef="PSI-MS" value="45.2"/>
+          </ns0:ProteinDetectionHypothesis>
+        </ns0:ProteinAmbiguityGroup>
+        <ns0:ProteinAmbiguityGroup id="group6">
+          <ns0:ProteinDetectionHypothesis id="id_prot6" passThreshold="false">
+            <ns0:PeptideHypothesis peptideEvidence_ref="PE1_Mas_spec6_pep2">
+              <ns0:SpectrumIdentificationItemRef spectrumIdentificationItem_ref="Mas_spec6_pep2"/>
+            </ns0:PeptideHypothesis>
+            <ns0:PeptideHypothesis peptideEvidence_ref="PE1_Mas_spec36b1_pep1">
+              <ns0:SpectrumIdentificationItemRef spectrumIdentificationItem_ref="Mas_spec36b1_pep1"/>
+            </ns0:PeptideHypothesis>
+            <ns0:PeptideHypothesis peptideEvidence_ref="PE1_Mas_spec40_pep1">
+              <ns0:SpectrumIdentificationItemRef spectrumIdentificationItem_ref="Mas_spec40_pep1"/>
+            </ns0:PeptideHypothesis>
+            <ns0:cvParam accession="MS:1001093" name="sequence coverage" cvRef="PSI-MS" value="0.43"/>
+            <ns0:cvParam accession="MS:1001301" name="protein rank" cvRef="PSI-MS" value="6"/>
+            <ns0:cvParam accession="MS:1001097" name="distinct peptide sequences" cvRef="PSI-MS" value="3"/>
+            <ns0:cvParam accession="MS:1001250" name="local FDR" cvRef="PSI-MS" value="33.33" unitAccession="UO:0000187" unitName="percent" unitCvRef="UO"/>
+            <ns0:cvParam accession="MS:1001507" name="ProteinExtractor:Score" cvRef="PSI-MS" value="40.9"/>
+          </ns0:ProteinDetectionHypothesis>
+        </ns0:ProteinAmbiguityGroup>
+        <ns0:ProteinAmbiguityGroup id="group7">
+          <ns0:ProteinDetectionHypothesis id="id_prot7" passThreshold="false">
+            <ns0:PeptideHypothesis peptideEvidence_ref="PE1_Mas_spec6_pep1">
+              <ns0:SpectrumIdentificationItemRef spectrumIdentificationItem_ref="Mas_spec6_pep1"/>
+            </ns0:PeptideHypothesis>
+            <ns0:PeptideHypothesis peptideEvidence_ref="PE1_Mas_spec35_pep1">
+              <ns0:SpectrumIdentificationItemRef spectrumIdentificationItem_ref="Mas_spec35_pep1"/>
+            </ns0:PeptideHypothesis>
+            <ns0:cvParam accession="MS:1001093" name="sequence coverage" cvRef="PSI-MS" value="0.53"/>
+            <ns0:cvParam accession="MS:1001301" name="protein rank" cvRef="PSI-MS" value="7"/>
+            <ns0:cvParam accession="MS:1001097" name="distinct peptide sequences" cvRef="PSI-MS" value="2"/>
+            <ns0:cvParam accession="MS:1001250" name="local FDR" cvRef="PSI-MS" value="28.57" unitAccession="UO:0000187" unitName="percent" unitCvRef="UO"/>
+            <ns0:cvParam accession="MS:1001507" name="ProteinExtractor:Score" cvRef="PSI-MS" value="40.9"/>
+          </ns0:ProteinDetectionHypothesis>
+        </ns0:ProteinAmbiguityGroup>
+      </ns0:ProteinDetectionList>
+    </ns0:AnalysisData>
+  </ns0:DataCollection>
+</ns0:MzIdentML>

--- a/tests/test_mzid.py
+++ b/tests/test_mzid.py
@@ -32,15 +32,6 @@ class MzidTest(unittest.TestCase):
                 parent_tolerance = protocol['ParentTolerance']
                 self.assertEqual(parent_tolerance['search tolerance plus value'].unit_info, 'parts per million')
 
-    def test_structure_normalization(self):
-        gen = read('mzid_snippet.xml').iterfind("SpectraData")
-        datum = next(gen)
-        index = aux.cvquery(datum)
-        assert index['MS:1000768'] == 'Thermo nativeID format'
-        datum = next(gen)
-        index = aux.cvquery(datum)
-        assert index['MS:1000774'] == 'multiple peak list nativeID format'
-
     def test_map(self):
         def key(x):
             return (x['spectrumID'], x['SpectrumIdentificationItem'][0]['PeptideSequence'], len(x['SpectrumIdentificationItem']))
@@ -58,6 +49,25 @@ class MzidTest(unittest.TestCase):
                     self.assertEqual(
                         len(mzid_spectra[(1, 1)]),
                         sum(1 for _ in r.iterfind("SpectrumIdentificationResult").map(method=method)))
+
+    def test_index(self):
+        with MzIdentML(self.path) as reader:
+            self.assertEqual(len(mzid_spectra[(1, 1)]), len(reader.index[MzIdentML._default_iter_tag]))
+
+
+class ExplicitNSMzidTest(MzidTest):
+    path = 'test.explicit-ns.mzid'
+
+
+class OtherTest(unittest.TestCase):
+    def test_structure_normalization(self):
+        gen = read('mzid_snippet.xml').iterfind("SpectraData")
+        datum = next(gen)
+        index = aux.cvquery(datum)
+        assert index['MS:1000768'] == 'Thermo nativeID format'
+        datum = next(gen)
+        index = aux.cvquery(datum)
+        assert index['MS:1000774'] == 'multiple peak list nativeID format'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This updates the pattern used by the XML byte offset index constructor to match elements with explicit  namespaces, and makes sure that those explicit namespaces are stripped afterwards in the output.

Fixes #199.

P.S. Test failure is unrelated.