### PR TITLE
ProForma support for inter-chain cross-linked peptides

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+dev
+---
+
+  - Support inter-chain cross-linked peptides, the ``//`` notation of ProForma
+    section 9.2.2. Such a string now parses instead of raising, into a
+    :py:class:`~.ProForma` holding several :py:attr:`~.ProForma.chains`. What
+    :py:func:`~.parse` returns is unchanged. This completes the ProForma 2.1
+    compliance checklist for cross-linking.
+  - Fix :py:meth:`~.TagBase.is_modification` omitting ``TagTypeEnum.xlmod``, so
+    a cross-linker was invisible to :py:meth:`~.ProForma.find_modification`.
+
 5.0.1
 -----
 

--- a/doc/source/api/proforma.rst
+++ b/doc/source/api/proforma.rst
@@ -183,7 +183,7 @@ Helpers
 High Level Interface
 --------------------
 
-.. autoclass:: PeptidoformIon
+.. autoclass:: ProFormaParseResult
 
 .. autoclass:: ProForma
 

--- a/doc/source/api/proforma.rst
+++ b/doc/source/api/proforma.rst
@@ -139,7 +139,18 @@ These features are independent from each other:
 
 4. Cross-Linking Extensions
 
-    - [ ]  Cross-linked peptides (using the XL-MOD CV/ontology, the prefix X MUST be used for XL-MOD CV/ontology term names).
+    - [x]  Cross-linked peptides (using the XL-MOD CV/ontology, the prefix X MUST be used for XL-MOD CV/ontology term names).
+
+      Broken out along the specification's own subdivision of section 9, since
+      the vocabulary and the multi-chain notation are separate requirements:
+
+      - [x]  The XL-MOD CV/ontology (section 9.1).
+      - [x]  Cross-links within a single peptide, including dead ends (section 9.2.1).
+      - [x]  Inter-chain cross-links, written with ``//`` (section 9.2.2). Such
+             a string parses to a :class:`ProForma` holding several
+             :attr:`~ProForma.chains`; the return type is unchanged and no
+             option selects this.
+      - [x]  Disulfide linkages (section 9.2.3).
 
 5. Glycan Extensions
 
@@ -171,6 +182,8 @@ Helpers
 
 High Level Interface
 --------------------
+
+.. autoclass:: PeptidoformIon
 
 .. autoclass:: ProForma
 

--- a/pyteomics/proforma.py
+++ b/pyteomics/proforma.py
@@ -136,6 +136,43 @@ def _cross_link_overcount_within(chain) -> Tuple[float, List[str]]:
     return excess, sorted(duplicated)
 
 
+def _cross_link_declared_compositions(chain) -> Dict[str, List[Any]]:
+    """Compositions declared for each cross-link group within one chain."""
+    declarations: Dict[str, List[Any]] = {}
+    for _position, tags in getattr(chain, 'sequence', ()) or ():
+        for tag in tags or ():
+            group = getattr(tag, 'group_id', None)
+            if not (group and str(group).startswith('#XL')):
+                continue
+            if not (tag.is_modification() and tag.has_composition()):
+                continue
+            try:
+                composition = tag.composition
+            except Exception:
+                continue
+            if composition is not None:
+                declarations.setdefault(str(group), []).append(composition)
+    return declarations
+
+
+def _cross_link_composition_overcount(chains):
+    """The composition counterpart of :func:`_cross_link_overcount`.
+
+    A linker declared on several chains is one molecule, so its atoms are
+    counted once, exactly as its mass is.
+    """
+    seen = set()
+    excess = Composition()
+    for chain in chains:
+        within = _cross_link_declared_compositions(chain)
+        for group, compositions in within.items():
+            start = 0 if group in seen else 1
+            seen.add(group)
+            for composition in compositions[start:]:
+                excess += composition
+    return excess
+
+
 def _cross_link_overcount(chains) -> Tuple[float, List[str]]:
     """Cross-linker mass counted more than once, and the groups responsible.
 
@@ -2876,13 +2913,13 @@ class Parser:
 
     def _close_ion(self):
         """End the peptidoform ion under construction."""
-        self.chains.append(self._finish_component())
+        self.chains.append(self._finish_chain())
         self.components.append(self.chains)
         self.chains = []
 
     def _handle_chain_separator(self):
         self.saw_chain_separator = True
-        self.chains.append(self._finish_component())
+        self.chains.append(self._finish_chain())
         self._reset_component()
 
     def _handle_chimeric_separator(self):
@@ -3346,7 +3383,7 @@ class Parser:
             self.index += 1
         return self.index < self.length
 
-    def _finish_component(self) -> PeptidoformIon:
+    def _finish_chain(self) -> ProFormaParseResult:
         if self.charge_buffer:
             charge_number = self.charge_buffer()
             if self.adduct_buffer:
@@ -4183,7 +4220,9 @@ class ProForma(object):
         elif other is None:
             return False
         else:
-            return self.sequence == other.sequence and self.properties == other.properties
+            return (self.sequence == other.sequence
+                    and self.properties == other.properties
+                    and self.additional_chains == getattr(other, 'additional_chains', []))
 
     def __ne__(self, other):
         return not self == other
@@ -4403,7 +4442,6 @@ class ProForma(object):
         -------
         float
         """
-        self._single_chain("mz()")
         charge_state = charge
         if charge_state is None:
             charge_state = self.charge_state
@@ -4473,6 +4511,8 @@ class ProForma(object):
                574.27188356, 703.31447664])
 
         """
+        # Fragmenting a covalently joined pair yields cross-linked fragment
+        # pairs, which this model has no way to express.
         self._single_chain("fragments()")
         if isinstance(ion_shift, str):
             if ion_shift[0] in 'xyz':
@@ -4583,6 +4623,15 @@ class ProForma(object):
         -------
         list[tuple[Any, TagBase]] or list[TagBase]
         '''
+        if self.additional_chains:
+            # Without positions the answer is unambiguous, and it is the one a
+            # cross-link group needs: the two ends of `#XL1` sit on different
+            # chains. With positions it is not -- an index means nothing until
+            # you know which chain it indexes.
+            if include_position:
+                self._single_chain("find_tags_by_id(include_position=True)")
+            return [tag for part in self.chains
+                    for tag in part.find_tags_by_id(tag_id, include_position=False)]
         if not tag_id.startswith("#"):
             tag_id = "#" + tag_id
         matches = []
@@ -4610,6 +4659,9 @@ class ProForma(object):
 
     @property
     def tags(self):
+        """Every tag on the molecule, across all of its chains."""
+        if self.additional_chains:
+            return [tag for part in self.chains for tag in part.tags]
         return [tag for tags_at in [pos[1] for pos in self if pos[1]] for tag in tags_at]
 
     def proteoforms(self, include_unmodified: bool = False, include_labile: bool = False, strip: bool = False, deepcopy: bool = False) -> Iterator["ProForma"]:
@@ -4637,6 +4689,8 @@ class ProForma(object):
         ------
         :class:`ProForma`
         """
+        # Enumerating localisations across chains is a product over chains,
+        # and the result would not be representable as a flat sequence.
         self._single_chain("proteoforms()")
         return iter(ProteoformCombinator(self, include_unmodified=include_unmodified, include_labile=include_labile, strip=strip, deepcopy=deepcopy))
 
@@ -4659,7 +4713,8 @@ class ProForma(object):
         ]:
             properties[k] = [v.copy() for v in properties[k]]
         properties['names'] = properties['names'].copy()
-        return self.__class__(sequence, properties)
+        return self.__class__(sequence, properties,
+                              [chain.copy() for chain in self.additional_chains])
 
     def composition(self, include_charge: Union[bool, ChargeState]=False, aa_comp=None, ignore_missing=False) -> Composition:
         '''
@@ -4689,7 +4744,20 @@ class ProForma(object):
         Composition
             :py:class:`Composition` object representing the composition of the ProForma sequence.
         '''
-        self._single_chain("composition()")
+        if self.additional_chains:
+            # One molecule, so one composition: the chains sum, and a linker
+            # declared on more than one of them is counted once, exactly as it
+            # is for `mass`.
+            total = Composition()
+            for part in self.chains:
+                total += part.composition(include_charge=False, aa_comp=aa_comp,
+                                          ignore_missing=ignore_missing)
+            total -= _cross_link_composition_overcount(self.chains)
+            if include_charge:
+                charge = self.charge_state if include_charge is True else include_charge
+                if charge is not None:
+                    total += charge.composition()
+            return total
         if ignore_missing:
             def get_comp(tag):
                 try:

--- a/pyteomics/proforma.py
+++ b/pyteomics/proforma.py
@@ -2720,6 +2720,8 @@ PEPTIDOFORM_NAME_CLOSE = ParserStateEnum.peptidoform_name_close
 
 DONE = ParserStateEnum.done
 
+INTER_CHAIN_CROSS_LINK_START = ParserStateEnum.inter_chain_cross_link_start
+
 VALID_AA_UPPER = set("QWERTYIPASDFGHKLCVNMXUOJZB")
 VALID_AA = {s.lower() for s in VALID_AA_UPPER} | VALID_AA_UPPER
 TERMINAL_SPEC_CHARS = set('N-term') | set('C-term') | set("ncT: ")
@@ -3493,7 +3495,7 @@ class Parser:
                 self.state,
             )
 
-        complete_states = (SEQ, POST_INTERVAL_TAG, POST_TAG_AFTER, CHARGE_NUMBER, ADDUCT_END)
+        complete_states = (SEQ, POST_INTERVAL_TAG, POST_TAG_AFTER, CHARGE_NUMBER, ADDUCT_END, INTER_CHAIN_CROSS_LINK_START)
         if self.state not in complete_states:
             raise ProFormaError(
                 f"Error In State {self.state}, incomplete ProForma string reached end of input",

--- a/pyteomics/proforma.py
+++ b/pyteomics/proforma.py
@@ -2735,12 +2735,17 @@ def _local_charges(
 #: ``(amino acid, tags)`` pairs; ``properties`` is everything that is not
 #: positional -- terminal, labile and unlocalized modifications, intervals,
 #: isotopes, group ids, charge state and names. A peptidoform written with
-#: ``//`` has one of these per chain; see :class:`PeptidoformIon`.
-ProFormaParseResult = Tuple[List[Tuple[str, Optional[List[TagBase]]]], Dict[str, Any]]
+#: ``//`` has one of these per chain; see :class:`ProFormaParseResult`, which is
+#: what :func:`parse` returns and which holds them.
+ProFormaChain = Tuple[List[Tuple[str, Optional[List[TagBase]]]], Dict[str, Any]]
 
 
-class PeptidoformIon(Sequence):
-    """One peptidoform ion: the chains of a molecule, as :func:`parse` returns them.
+class ProFormaParseResult(Sequence):
+    """What :func:`parse` returns: the chains of one peptidoform ion.
+
+    This is parser plumbing, not the representation of a cross-linked peptide.
+    That is :class:`ProForma`, which gained a :attr:`~ProForma.chains`
+    collection; there is no separate type for a molecule spanning chains.
 
     Almost every ProForma string describes a single chain, and for that case
     this behaves exactly as the ``(positions, properties)`` pair it used to be
@@ -2754,7 +2759,7 @@ class PeptidoformIon(Sequence):
 
     __slots__ = ("chains",)
 
-    def __init__(self, chains: List[ProFormaParseResult]):
+    def __init__(self, chains: List[ProFormaChain]):
         self.chains = list(chains)
 
     def __len__(self):
@@ -2767,7 +2772,7 @@ class PeptidoformIon(Sequence):
         return iter(self.chains[0])
 
     def __eq__(self, other):
-        if isinstance(other, PeptidoformIon):
+        if isinstance(other, ProFormaParseResult):
             return self.chains == other.chains
         return tuple(self.chains[0]) == tuple(other)
 
@@ -3383,7 +3388,7 @@ class Parser:
             self.index += 1
         return self.index < self.length
 
-    def _finish_chain(self) -> ProFormaParseResult:
+    def _finish_chain(self) -> ProFormaChain:
         if self.charge_buffer:
             charge_number = self.charge_buffer()
             if self.adduct_buffer:
@@ -3441,7 +3446,7 @@ class Parser:
 
     def finish(
         self,
-    ) -> Union[PeptidoformIon, Chimeric[PeptidoformIon]]:
+    ) -> Union[ProFormaParseResult, Chimeric[ProFormaParseResult]]:
         """
         Post-process the parser's accumulated parsed token data and return the parsed
         sequence and metadata.
@@ -3459,13 +3464,13 @@ class Parser:
         for ion in self.components:
             if len(ion) > 1:
                 self._dedupe_ion_names(ion)
-        packed = [PeptidoformIon(ion) for ion in self.components]
+        packed = [ProFormaParseResult(ion) for ion in self.components]
         if self.chimeric:
             return Chimeric(packed, len(packed) > 1)
         return packed[0]
 
     @staticmethod
-    def _dedupe_ion_names(ion: List[ProFormaParseResult]) -> None:
+    def _dedupe_ion_names(ion: List[ProFormaChain]) -> None:
         """Keep the ion and set names on the first chain only.
 
         The ``(>>name)`` and ``(>>>name)`` describe tiers above a chain -- the
@@ -3515,20 +3520,20 @@ class Parser:
 
 
 @overload
-def parse(sequence: str, *, chimeric: Literal[False] = False, **kwargs) -> PeptidoformIon:  # pragma: no cover
+def parse(sequence: str, *, chimeric: Literal[False] = False, **kwargs) -> ProFormaParseResult:  # pragma: no cover
     ...
 
 
 @overload
 def parse(
     sequence: str, *, chimeric: Literal[True], **kwargs
-) -> Chimeric[PeptidoformIon]:  # pragma: no cover
+) -> Chimeric[ProFormaParseResult]:  # pragma: no cover
     ...
 
 
 def parse(
     sequence: str, *, chimeric: bool = False, **kwargs
-) -> Union[PeptidoformIon, Chimeric[PeptidoformIon]]:
+) -> Union[ProFormaParseResult, Chimeric[ProFormaParseResult]]:
     """
     Tokenize a ProForma sequence into a sequence of amino acid+tag positions, and a
     mapping of sequence-spanning modifiers.
@@ -3551,7 +3556,7 @@ def parse(
     Notes
     -----
 A string that joins chains with ``//`` puts the further chains in
-    :attr:`PeptidoformIon.chains`; the return type does not change. No
+    :attr:`ProFormaParseResult.chains`; the return type does not change. No
     option selects this: ``//`` is only reachable once a peptidoform is
     complete, so it is never ambiguous with a slash inside a tag, a name or a
     charge state.
@@ -3566,7 +3571,7 @@ A string that joins chains with ``//`` puts the further chains in
     """
     # short-circuiting the parser for simple sequences with no tags or modifications to avoid overhead
     if sequence.isupper() and sequence.isalpha():
-        result = PeptidoformIon([(
+        result = ProFormaParseResult([(
             [(aa, None) for aa in sequence],
             Parser.empty_properties()
         )])
@@ -4335,7 +4340,7 @@ class ProForma(object):
         """
         result = parse(string, chimeric=chimeric, **kwargs)
 
-        def build(ion: PeptidoformIon) -> "ProForma":
+        def build(ion: ProFormaParseResult) -> "ProForma":
             first, *rest = ion.chains
             return cls(*first, additional_chains=[cls(*chain) for chain in rest])
 

--- a/pyteomics/proforma.py
+++ b/pyteomics/proforma.py
@@ -102,6 +102,64 @@ class Chimeric(Generic[T], Sequence[T]):
         return value in self.peptides
 
 
+def _cross_link_declarations(chain) -> Dict[str, List[float]]:
+    """Masses declared for each cross-link group within one chain."""
+    declarations: Dict[str, List[float]] = {}
+    for _position, tags in getattr(chain, 'sequence', ()) or ():
+        for tag in tags or ():
+            group = getattr(tag, 'group_id', None)
+            if not (group and str(group).startswith('#XL')):
+                continue
+            if not (tag.is_modification() and tag.has_mass()):
+                continue
+            try:
+                mass = tag.mass
+            except Exception:
+                continue
+            declarations.setdefault(str(group), []).append(mass)
+    return declarations
+
+
+def _cross_link_overcount_within(chain) -> Tuple[float, List[str]]:
+    """Linker mass a single chain counts more than once.
+
+    Section 9.2.1 requires a self-link be written once, the other site carrying
+    a bare ``[#XL1]``. Repeating it inside one chain is redundant rather than
+    useful, so it is both discounted and reported.
+    """
+    excess = 0.0
+    duplicated = []
+    for group, masses in _cross_link_declarations(chain).items():
+        if len(masses) > 1:
+            duplicated.append(group)
+            excess += sum(masses[1:])
+    return excess, sorted(duplicated)
+
+
+def _cross_link_overcount(chains) -> Tuple[float, List[str]]:
+    """Cross-linker mass counted more than once, and the groups responsible.
+
+    Repeating a declaration across chains is useful rather than redundant: it
+    lets each chain be read on its own, without hunting through the others for
+    what ``#XL1`` refers to, and section 9.2.2 writes its examples both ways.
+    The two spellings denote one molecule and must agree, so every chain after
+    the first to declare a group is discounted.
+    """
+    seen: Dict[str, float] = {}
+    excess = 0.0
+    duplicated = []
+    for chain in chains:
+        # Each chain has already discounted its own repeats, so only the first
+        # declaration per chain is in play here.
+        for group, masses in _cross_link_declarations(chain).items():
+            if group in seen:
+                duplicated.append(group)
+                excess += masses[0]
+            else:
+                seen[group] = masses[0]
+    return excess, sorted(set(duplicated))
+
+
 class ProFormaError(PyteomicsError):
     def __init__(self, message, index=None, parser_state=None, **kwargs):
         super(ProFormaError, self).__init__(PyteomicsError, message, index, parser_state)
@@ -274,6 +332,9 @@ class TagBase(object):
             TagTypeEnum.massmod,
             TagTypeEnum.psimod,
             TagTypeEnum.custom,
+            # XL-MOD was omitted when cross-linking support was added, so
+            # `find_modification` could not see a cross-linker.
+            TagTypeEnum.xlmod,
         )
 
     def find_modification(self) -> Optional["TagBase"]:
@@ -2632,7 +2693,52 @@ def _local_charges(
     return local_charges, n_charged_modifications
 
 
+#: One parsed chain: the ``(positions, properties)`` pair that :class:`ProForma`
+#: is constructed from. ``positions`` is the primary sequence as
+#: ``(amino acid, tags)`` pairs; ``properties`` is everything that is not
+#: positional -- terminal, labile and unlocalized modifications, intervals,
+#: isotopes, group ids, charge state and names. A peptidoform written with
+#: ``//`` has one of these per chain; see :class:`PeptidoformIon`.
 ProFormaParseResult = Tuple[List[Tuple[str, Optional[List[TagBase]]]], Dict[str, Any]]
+
+
+class PeptidoformIon(Sequence):
+    """One peptidoform ion: the chains of a molecule, as :func:`parse` returns them.
+
+    Almost every ProForma string describes a single chain, and for that case
+    this behaves exactly as the ``(positions, properties)`` pair it used to be
+    -- it unpacks, indexes and compares the same way, so
+    ``positions, properties = parse(s)`` is unchanged.
+
+    A string joining chains with ``//`` describes one molecule held together by
+    cross-links spanning them. Those further chains are in :attr:`chains`; the
+    tuple behaviour continues to describe the first.
+    """
+
+    __slots__ = ("chains",)
+
+    def __init__(self, chains: List[ProFormaParseResult]):
+        self.chains = list(chains)
+
+    def __len__(self):
+        return 2
+
+    def __getitem__(self, i):
+        return self.chains[0][i]
+
+    def __iter__(self):
+        return iter(self.chains[0])
+
+    def __eq__(self, other):
+        if isinstance(other, PeptidoformIon):
+            return self.chains == other.chains
+        return tuple(self.chains[0]) == tuple(other)
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __repr__(self):  # pragma: no cover
+        return "{self.__class__.__name__}({self.chains})".format(self=self)
 
 
 class Parser:
@@ -2697,7 +2803,12 @@ class Parser:
         self.state = ParserStateEnum.before_sequence
         self._VALID_AA = VALID_AA if not case_sensitive_aa else VALID_AA_UPPER
         self.chimeric = chimeric
+        # `components` holds peptidoform ions, each a list of chains. Most
+        # strings yield one ion of one chain; `//` is what adds chains, and it
+        # is unambiguous wherever it can be reached, so it needs no opting in.
+        self.saw_chain_separator = False
         self.components = []
+        self.chains = []
 
         self.fixed_modifications = []
         self.isotopes = []
@@ -2742,6 +2853,10 @@ class Parser:
         self.names = {}
         if 3 in names:
             self.names[3] = names[3]
+        # The ion-level name belongs to the whole ion, so it survives a `//`
+        # boundary. `_handle_chimeric_separator` clears it when the ion ends.
+        if 2 in names and self._in_ion:
+            self.names[2] = names[2]
 
     def _chimeric_disabled_error(self):
         raise ProFormaError(
@@ -2754,10 +2869,28 @@ class Parser:
             self.state,
         )
 
+    @property
+    def _in_ion(self) -> bool:
+        """Whether a ``//`` has already been seen in the ion being parsed."""
+        return bool(self.chains)
+
+    def _close_ion(self):
+        """End the peptidoform ion under construction."""
+        self.chains.append(self._finish_component())
+        self.components.append(self.chains)
+        self.chains = []
+
+    def _handle_chain_separator(self):
+        self.saw_chain_separator = True
+        self.chains.append(self._finish_component())
+        self._reset_component()
+
     def _handle_chimeric_separator(self):
         if not self.chimeric:
             self._chimeric_disabled_error()
-        self.components.append(self._finish_component())
+        self._close_ion()
+        # The ion-level name does not carry across a chimeric boundary.
+        self.names.pop(2, None)
         self._reset_component()
 
     def handle_before(self, c: str):
@@ -3066,12 +3199,11 @@ class Parser:
             self.charge_buffer.append(c)
             self.state = CHARGE_NUMBER
         elif c == "/":
+            # A second `/` means the charge that appeared to be starting is
+            # really a chain separator; the charge, if any, follows the last
+            # chain and belongs to the ion.
             self.state = ParserStateEnum.inter_chain_cross_link_start
-            raise ProFormaError(
-                "Inter-chain cross-linked peptides are not yet supported",
-                self.index,
-                self.state,
-            )
+            self._handle_chain_separator()
         elif c == '[':
             self.state = ParserStateEnum.charge_state_adduct_start
             self.depth = 1
@@ -3214,7 +3346,7 @@ class Parser:
             self.index += 1
         return self.index < self.length
 
-    def _finish_component(self) -> ProFormaParseResult:
+    def _finish_component(self) -> PeptidoformIon:
         if self.charge_buffer:
             charge_number = self.charge_buffer()
             if self.adduct_buffer:
@@ -3265,14 +3397,14 @@ class Parser:
         }
 
     def _apply_shared_properties(self):
-        for _positions, props in self.components:
+        for _positions, props in (chain for ion in self.components for chain in ion):
             props["fixed_modifications"] = list(self.fixed_modifications)
             props["isotopes"] = list(self.isotopes)
             props["group_ids"] = sorted(set(props["group_ids"]) | self.shared_group_ids)
 
     def finish(
         self,
-    ) -> Union[ProFormaParseResult, Chimeric[ProFormaParseResult]]:
+    ) -> Union[PeptidoformIon, Chimeric[PeptidoformIon]]:
         """
         Post-process the parser's accumulated parsed token data and return the parsed
         sequence and metadata.
@@ -3285,12 +3417,32 @@ class Parser:
             All other information outside the main sequence, including unlocalized, labile, or global modifications,
             names, charge states, and more.
         """
-        component = self._finish_component()
+        self._close_ion()
+        self._apply_shared_properties()
+        for ion in self.components:
+            if len(ion) > 1:
+                self._dedupe_ion_names(ion)
+        packed = [PeptidoformIon(ion) for ion in self.components]
         if self.chimeric:
-            self.components.append(component)
-            self._apply_shared_properties()
-            return Chimeric(self.components, len(self.components) > 1)
-        return component
+            return Chimeric(packed, len(packed) > 1)
+        return packed[0]
+
+    @staticmethod
+    def _dedupe_ion_names(ion: List[ProFormaParseResult]) -> None:
+        """Keep the ion and set names on the first chain only.
+
+        The ``(>>name)`` and ``(>>>name)`` describe tiers above a chain -- the
+        data schema in the specification's Appendix II puts them on the
+        peptidoform ion and the set -- but the parser records them on every
+        chain they span. Left there, each chain would serialise them, emitting
+        one copy per chain. Keeping them on the first is enough, since that is
+        where the string writes them.
+        """
+        for _positions, props in ion[1:]:
+            names = props.get("names")
+            if names:
+                names.pop(2, None)
+                names.pop(3, None)
 
     def _local_charges(self) -> Tuple[int, int]:
         return _local_charges(
@@ -3326,20 +3478,20 @@ class Parser:
 
 
 @overload
-def parse(sequence: str, *, chimeric: Literal[False] = False, **kwargs) -> ProFormaParseResult:  # pragma: no cover
+def parse(sequence: str, *, chimeric: Literal[False] = False, **kwargs) -> PeptidoformIon:  # pragma: no cover
     ...
 
 
 @overload
 def parse(
     sequence: str, *, chimeric: Literal[True], **kwargs
-) -> Chimeric[ProFormaParseResult]:  # pragma: no cover
+) -> Chimeric[PeptidoformIon]:  # pragma: no cover
     ...
 
 
 def parse(
     sequence: str, *, chimeric: bool = False, **kwargs
-) -> Union[ProFormaParseResult, Chimeric[ProFormaParseResult]]:
+) -> Union[PeptidoformIon, Chimeric[PeptidoformIon]]:
     """
     Tokenize a ProForma sequence into a sequence of amino acid+tag positions, and a
     mapping of sequence-spanning modifiers.
@@ -3359,6 +3511,14 @@ def parse(
     **kwargs :
         Forwarded to :class:`Parser`
 
+    Notes
+    -----
+A string that joins chains with ``//`` puts the further chains in
+    :attr:`PeptidoformIon.chains`; the return type does not change. No
+    option selects this: ``//`` is only reachable once a peptidoform is
+    complete, so it is never ambiguous with a slash inside a tag, a name or a
+    charge state.
+
     Returns
     -------
     parsed_sequence: list[tuple[str, list[TagBase]]]
@@ -3369,10 +3529,10 @@ def parse(
     """
     # short-circuiting the parser for simple sequences with no tags or modifications to avoid overhead
     if sequence.isupper() and sequence.isalpha():
-        result = (
+        result = PeptidoformIon([(
             [(aa, None) for aa in sequence],
             Parser.empty_properties()
-        )
+        )])
         if chimeric:
             return Chimeric([result], chimeric=False)
         return result
@@ -3885,12 +4045,19 @@ class ProForma(object):
 
     sequence: List[Tuple[str, Optional[List[TagBase]]]]
     properties: Dict[str, Any]
+    additional_chains: List["ProForma"]
 
-    def __init__(self, sequence, properties):
+    def __init__(self, sequence, properties, additional_chains=None):
         """
         Initialize a :class:`ProForma` instance from a parse tree.
 
         To construct an instance from a string directly, see :meth:`ProForma.parse`.
+
+        Parameters
+        ----------
+        additional_chains : list[ProForma], optional
+            Further chains covalently joined to this one, as written with ``//``.
+            See :attr:`chains`.
 
         See Also
         --------
@@ -3898,6 +4065,42 @@ class ProForma(object):
         """
         self.sequence = sequence
         self.properties = properties
+        self.additional_chains = list(additional_chains or ())
+
+    @property
+    def chains(self) -> List["ProForma"]:
+        """Every chain of this peptidoform ion, in the order written.
+
+        A peptidoform written with ``//`` is several chains held together by
+        cross-links spanning them, and is one molecule: it has one mass and one
+        charge. Almost every string is a single chain, in which case this is
+        just ``[self]`` and nothing else about the object differs.
+
+        The attributes describing a sequence -- :attr:`sequence`, indexing,
+        :meth:`find_tags_by_id` -- describe the *first* chain. Quantities that
+        are properties of the whole molecule -- :attr:`mass`,
+        :attr:`charge_state`, ``str()`` -- span all of them. Operations with no
+        meaningful multi-chain answer, such as :meth:`fragments`, raise.
+        """
+        if not self.additional_chains:
+            return [self]
+        # The first chain on its own, not the whole ion: `self` aggregates every
+        # chain, so returning it here would count the others twice.
+        first = self.__class__(self.sequence, self.properties)
+        return [first, *self.additional_chains]
+
+    @property
+    def is_multichain(self) -> bool:
+        """Whether this peptidoform ion has more than one chain."""
+        return bool(self.additional_chains)
+
+    def _single_chain(self, what: str):
+        """Refuse an operation that has no meaning across several chains."""
+        if self.additional_chains:
+            raise ValueError(
+                "%s is defined for a single chain, but this peptidoform ion has %d. "
+                "Iterate `.chains` and act on each one." % (what, len(self.chains))
+            )
 
     isotopes = _ProFormaProperty[List[StableIsotope]]('isotopes')
     _charge_state = _ProFormaProperty('charge_state')
@@ -3914,7 +4117,10 @@ class ProForma(object):
     group_ids = _ProFormaProperty('group_ids')
 
     def __str__(self):
-        return to_proforma(self.sequence, **self.properties)
+        text = to_proforma(self.sequence, **self.properties)
+        if self.additional_chains:
+            text = "//".join([text] + [str(chain) for chain in self.additional_chains])
+        return text
 
     def __repr__(self):  # pragma: no cover
         return "{self.__class__.__name__}({self.sequence}, {self.properties})".format(self=self)
@@ -3992,8 +4198,17 @@ class ProForma(object):
         instance, which includes the total charge state and adduct list.
 
         This implies that you have a peptidoform *ion*, not a neutral peptide.
+
+        Where the peptidoform spans several chains the charge belongs to the ion
+        as a whole and the string writes it after the last chain, so whichever
+        chain declares one answers for all of them.
         """
         z = self._charge_state
+        if z is None:
+            for chain in self.additional_chains:
+                z = chain._charge_state
+                if z is not None:
+                    break
         return z
 
     def _local_charges(self) -> Tuple[int, int]:
@@ -4080,10 +4295,14 @@ class ProForma(object):
         ProForma or Chimeric[ProForma]
         """
         result = parse(string, chimeric=chimeric, **kwargs)
-        if chimeric:
 
-            return Chimeric([cls(*component) for component in result], result.chimeric)
-        return cls(*result)
+        def build(ion: PeptidoformIon) -> "ProForma":
+            first, *rest = ion.chains
+            return cls(*first, additional_chains=[cls(*chain) for chain in rest])
+
+        if chimeric:
+            return Chimeric([build(ion) for ion in result], result.chimeric)
+        return build(result)
 
     @property
     def mass(self) -> float:
@@ -4135,6 +4354,27 @@ class ProForma(object):
             for tag in iv.tags or ():
                 if tag.has_mass():
                     mass += tag.mass
+        # A cross-link is one molecule however many sites it bridges. Section
+        # 9.2.1 requires a self-link be written once, the other site carrying a
+        # bare [#XL1]; where a string repeats the declaration instead, the
+        # linker would otherwise be counted once per declaration.
+        if any(str(group).startswith("#XL") for group in self.properties.get("group_ids") or ()):
+            excess, duplicated = _cross_link_overcount_within(self)
+            if duplicated:
+                warnings.warn(
+                    "Cross-link group(s) %s are declared more than once within a single "
+                    "peptide. The specification asks that a self-link be written once, "
+                    "with the other site a bare reference such as [#XL1]. Each linker has "
+                    "been counted once regardless." % ", ".join(duplicated)
+                )
+            mass -= excess
+        if self.additional_chains:
+            # Chains joined by // are one molecule. Each chain has already
+            # discounted its own repeats, so only cross-links spanning chains
+            # remain to be counted once.
+            mass += sum(chain.mass for chain in self.additional_chains)
+            across, _ = _cross_link_overcount(self.chains)
+            mass -= across
         return mass
 
     def mz(self, charge: Union[int, ChargeState, None] = None, **kwargs) -> float:
@@ -4163,6 +4403,7 @@ class ProForma(object):
         -------
         float
         """
+        self._single_chain("mz()")
         charge_state = charge
         if charge_state is None:
             charge_state = self.charge_state
@@ -4232,6 +4473,7 @@ class ProForma(object):
                574.27188356, 703.31447664])
 
         """
+        self._single_chain("fragments()")
         if isinstance(ion_shift, str):
             if ion_shift[0] in 'xyz':
                 reverse = True
@@ -4395,6 +4637,7 @@ class ProForma(object):
         ------
         :class:`ProForma`
         """
+        self._single_chain("proteoforms()")
         return iter(ProteoformCombinator(self, include_unmodified=include_unmodified, include_labile=include_labile, strip=strip, deepcopy=deepcopy))
 
     peptidoforms = proteoforms
@@ -4446,6 +4689,7 @@ class ProForma(object):
         Composition
             :py:class:`Composition` object representing the composition of the ProForma sequence.
         '''
+        self._single_chain("composition()")
         if ignore_missing:
             def get_comp(tag):
                 try:

--- a/tests/test_proforma.py
+++ b/tests/test_proforma.py
@@ -840,15 +840,56 @@ class InterChainCrossLinkTest(unittest.TestCase):
         self.assertEqual(pf.chains, [pf])
 
     def test_operations_with_no_multichain_meaning_refuse(self):
+        # Only these two. Fragmenting a covalently joined pair yields
+        # cross-linked fragment pairs, and enumerating localisations across
+        # chains is a product over chains; neither is representable here.
         ion = ProForma.parse("PEPK[XLMOD:02001#XL1]//TIDEK[#XL1]")
         for call in (lambda: ion.fragments("b", 1),
-                     lambda: ion.composition(),
-                     lambda: ion.mz(charge=2),
                      lambda: list(ion.proteoforms())):
             with self.subTest(call=call):
                 with self.assertRaises(ValueError) as caught:
                     call()
                 self.assertIn(".chains", str(caught.exception))
+
+    def test_composition_and_mz_span_the_chains(self):
+        # Whatever `mass` can answer for the whole molecule, `composition` and
+        # `mz` can answer too -- they are the same arithmetic.
+        ion = ProForma.parse("SEK[XLMOD:02001#XL1]UENCE//EMEVTK[#XL1]SESPEK")
+        self.assertAlmostEqual(ion.composition().mass(), ion.mass, 6)
+        self.assertAlmostEqual(ion.mz(charge=2), (ion.mass + 2 * 1.00727646677) / 2, 4)
+
+    def test_composition_counts_a_linker_once(self):
+        once = ProForma.parse("SEK[XLMOD:02001#XL1]UENCE//EMEVTK[#XL1]SESPEK")
+        both = ProForma.parse(
+            "SEK[XLMOD:02001#XL1]UENCE//EMEVTK[XLMOD:02001#XL1]SESPEK")
+        self.assertAlmostEqual(once.composition().mass(), both.composition().mass(), 6)
+
+    def test_copy_keeps_every_chain(self):
+        ion = ProForma.parse("SEK[XLMOD:02001#XL1]UENCE//EMEVTK[#XL1]SESPEK")
+        duplicate = ion.copy()
+        self.assertEqual(len(duplicate.chains), 2)
+        self.assertEqual(str(duplicate), str(ion))
+        self.assertEqual(duplicate, ion)
+
+    def test_a_cross_link_group_is_found_across_chains(self):
+        # The whole point of a group is that its ends are apart, and here they
+        # are on different chains. Without positions the answer is unambiguous,
+        # so it spans; with positions an index means nothing until you know
+        # which chain it indexes, so it refuses.
+        ion = ProForma.parse("SEK[XLMOD:02001#XL1]UENCE//EMEVTK[#XL1]SESPEK")
+        self.assertEqual(len(ion.find_tags_by_id("#XL1", include_position=False)), 2)
+        self.assertEqual(len(ion.tags), 2)
+        with self.assertRaises(ValueError):
+            ion.find_tags_by_id("#XL1")
+        # Unchanged for one chain.
+        single = ProForma.parse("EMEVTK[XLMOD:02001#XL1]SESPEK[#XL1]")
+        self.assertEqual(len(single.find_tags_by_id("#XL1")), 2)
+
+    def test_a_two_chain_ion_is_not_its_first_chain(self):
+        # Equality has to see the other chains, or two different molecules
+        # compare equal.
+        ion = ProForma.parse("SEK[XLMOD:02001#XL1]UENCE//EMEVTK[#XL1]SESPEK")
+        self.assertNotEqual(ion, ProForma.parse("SEK[XLMOD:02001#XL1]UENCE"))
 
     def test_a_slash_inside_a_tag_or_name_is_not_a_separator(self):
         for seq in ("PEP[INFO:http://example.com/a]TIDE",

--- a/tests/test_proforma.py
+++ b/tests/test_proforma.py
@@ -2,6 +2,7 @@ import sys
 import os
 from os import path
 import unittest
+import warnings
 import pickle
 import math
 import pyteomics
@@ -21,6 +22,10 @@ if CACHE_PATH:
     obo_cache.cache_path = CACHE_PATH
 
 obo_cache.enabled = bool(os.environ.get("OBO_CACHE_ENABLED"))
+
+
+INSULIN = ("FVNQHLC[MOD:00034#XL1]GSHLVEALYLVC[MOD:00034#XL2]GERGFFYTPKA"
+           "//GIVEQC[MOD:00034#XL3]C[#XL1]TSIC[#XL3]SLYQLENYC[#XL2]N")
 
 
 class ProFormaTest(unittest.TestCase):
@@ -402,7 +407,7 @@ class ProFormaTest(unittest.TestCase):
             "[+1]-A[+1]-[+1]",
             # "AA+AA",
             "EMK[XLMOD:02000#XL1]EVTKSE[XLMOD:02010#XL2]SK[#XL1]PEK[#XL2]AR",
-            # "SEK[XLMOD:02001#XL1]UENCE//EMEVTK[XLMOD:02001#XL1]SESPEK",
+            "SEK[XLMOD:02001#XL1]UENCE//EMEVTK[XLMOD:02001#XL1]SESPEK",
             "EM[Oxidation]EVEES[Phospho]PEK",
             # "EM[R: Methionine sulfone]EVEES[O-phospho-L-serine]PEK",
             "EMEVTK[X:DSS#XL1]SESPEK",
@@ -429,8 +434,8 @@ class ProFormaTest(unittest.TestCase):
             "SEQUEN[Glycan:HexNAc]CE",
             "EMEVTK[XLMOD:02001#XL1]SESPEK[#XL1]",
             "EMEVTK[XLMOD:02001#XL1]SESPEK",
-            # "SEK[XLMOD:02001#XL1]UENCE//EMEVTK[XLMOD:02001#XL1]SESPEK",
-            # "ETFGD[MOD:00093#BRANCH]//R[#BRANCH]ATER",
+            "SEK[XLMOD:02001#XL1]UENCE//EMEVTK[XLMOD:02001#XL1]SESPEK",
+            "ETFGD[MOD:00093#BRANCH]//R[#BRANCH]ATER",
             "(?DQ)NGTWEM[Oxidation]ESNENFEGYM[Oxidation]K",
             "ELVIS[Phospho|+79.966331]K",
             "ELVIS[Phospho|Obs:+79.978]K",
@@ -442,7 +447,7 @@ class ProFormaTest(unittest.TestCase):
             "EMEVEESPEK/2",
             "EMEVEESPEK+ELVISLIVER",
             "EMEVEESPEK/2+ELVISLIVER/3",
-            # "A[X:DSS#XL1]//B[#XL1]+C[X:DSS#XL1]//D[#XL1]",
+            "A[X:DSS#XL1]//B[#XL1]+C[X:DSS#XL1]//D[#XL1]",
             "<[Carbamidomethyl]@C>ATPEILTCNSIGCLK",
             "<[Oxidation]@C,M>MTPEILTCNSIGCLK",
             "<[TMT6plex]@K,N-term>ATPEILTCNSIGCLK",
@@ -466,20 +471,21 @@ class ProFormaTest(unittest.TestCase):
             "EMK[XLMOD:02000#XL1]EVTKSE[XLMOD:02010#XL2]SK[#XL1]PEK[#XL2]AR",
             "EMEVTK[XLMOD:02001#XL1]SESPEK",
             "EMEVTK[XLMOD:02001]SESPEK",
-            # "SEK[XLMOD:02001#XL1]UENCE//EMEVTK[XLMOD:02001#XL1]SESPEK",
-            # "SEK[XLMOD:02001#XL1]UENCE//EMEVTK[#XL1]SESPEK",
+            "SEK[XLMOD:02001#XL1]UENCE//EMEVTK[XLMOD:02001#XL1]SESPEK",
+            "SEK[XLMOD:02001#XL1]UENCE//EMEVTK[#XL1]SESPEK",
             "EVTSEKC[MOD:00034#XL1]LEMSC[#XL1]EFD",
             "EVTSEKC[L-cystine (cross-link)#XL1]LEMSC[#XL1]EFD",
             "FVNQHLC[MOD:00034#XL1]GSHLVEALYLVC[MOD:00034#XL2]GERGFFYTPK",
-            # "A//GIVEQC[MOD:00034#XL3]C[#XL1]TSIC[#XL3]SLYQLENYC[#XL2]N",
+            "FVNQHLC[MOD:00034#XL1]GSHLVEALYLVC[MOD:00034#XL2]GERGFFYTPKA"
+            "//GIVEQC[MOD:00034#XL3]C[#XL1]TSIC[#XL3]SLYQLENYC[#XL2]N",
             "EVTSEKC[XLMOD:02009#XL1]LEMSC[#XL1]EFD",
             "EVTSEKC[X:Disulfide#XL1]LEMSC[#XL1]EFD",
             "EVTSEKC[half cystine]LEMSC[half cystine]EFD",
             "EVTSEKC[MOD:00798]LEMSC[MOD:00798]EFDEVTSEKC[MOD:00798]LEMSC[MOD:00798]EFD",
             "EVTSEKC[UNIMOD:374#XL1]LEMSC[#XL1]EFD",
             "EVTSEKC[Dehydro#XL1]LEMSC[#XL1]EFD",
-            # "ETFGD[MOD:00093#BRANCH]//R[#BRANCH]ATER",
-            # "AVTKYTSSK[MOD:00134#BRANCH]//AGKQLEDGRTLSDYNIQKESTLHLVLRLRG-[#BRANCH]",
+            "ETFGD[MOD:00093#BRANCH]//R[#BRANCH]ATER",
+            "AVTKYTSSK[MOD:00134#BRANCH]//AGKQLEDGRTLSDYNIQKESTLHLVLRLRG-[#BRANCH]",
             "NEEYN[GNO:G59626AS]K",
             "YPVLN[GNO:G62765YT]VTMPN[GNO:G02815KT]NSNGKFDK",
             "EM[+15.9949]EVEES[+79.9663]PEK",
@@ -568,8 +574,8 @@ class ProFormaTest(unittest.TestCase):
             "PETIEM[Dioxidation#1][Oxidation#2]REM[#1][#2]REM[#2]RM[#1]PEPTIDE",
             "[Oxidation|CoMKP]?PEPT[Phospho]IDE",
             "(>Trypsin)AANSIPYQVSLNS",
-            # "(>P07225 Vitamin K-dependent protein S OS=Homo sapiens OX=9606 GN=PROS1 PE=1 (SV=1) RANGE=12..42)GGK[xlink:dss[138]#XLDSS]IEVQLK//(>P07225 Vitamin K-dependent protein S OS=Homo sapiens OX=9606 GN=PROS1 PE=1 SV=1)KVESELIK[#XLDSS]PINPR/4",
-            # "(>>>Trastuzumab Fab and coeluting Fc)(>>Fab)(>Heavy chain)EVQLVESGGGLVQPGGSLRLSC[M:l-cystine (cross-link)#XL1]AASGFNIKDTYIHWVRQAPGKGLEWVARIYPTNGYTRYADSVKGRFTISADTSKNTAYLQMNSLRAEDTAVYYC[#XL1]SRWGGDGFYAMDYWGQGTLVTVSSASTKGPSVFPLAPSSKSTSGGTAALGC[M:l-cystine (cross-link)#XL2]LVKDYFPEPVTVSWNSGALTSGVHTFPAVLQSSGLYSLSSVVTVPSSSLGTQTYIC[#XL2]NVNHKPSNTKVDKKVEPKSC[M:l-cystine (cross-link)#XL3]DKT//(>Light chain)DIQMTQSPSSLSASVGDRVTITC[M:l-cystine (cross-link)#XL4]RASQDVNTAVAWYQQKPGKAPKLLIYSASFLYSGVPSRFSGSRSGTDFTLTISSLQPEDFATYYC[#XL4]QQHYTTPPTFGQGTKVEIKRTVAAPSVFIFPPSDEQLKSGTASVVC[M:l-cystine (cross-link)#XL5]LLNNFYPREAKVQWKVDNALQSGNSQESVTEQDSKDSTYSLSSTLTLSKADYEKHKVYAC[#XL5]EVTHQGLSSPVTKSFNRGEC[#XL3]+(>Fc)HTCPPCPAPELLGGPSVFLFPPKPKDTLMISRTPEVTCVVVDVSHEDPEVKFNWYVDGVEVHNAKTKPREEQYNSTYRVVSVLTVLHQDWLNGKEYKCKVSNKALPAPIEKTISKAKGQPREPQVYTLPPSREEMTKNQVSLTCLVKGFYPSDIAVEWESNGQPENNYKTTPPVLDSDGSFFLYSKLTVDKSRWQQGNVFSCSVMHEALHNHYTQKSLSLSPGK",
+            "(>P07225 Vitamin K-dependent protein S OS=Homo sapiens OX=9606 GN=PROS1 PE=1 (SV=1) RANGE=12..42)GGK[xlink:dss[138]#XLDSS]IEVQLK//(>P07225 Vitamin K-dependent protein S OS=Homo sapiens OX=9606 GN=PROS1 PE=1 SV=1)KVESELIK[#XLDSS]PINPR/4",
+            "(>>>Trastuzumab Fab and coeluting Fc)(>>Fab)(>Heavy chain)EVQLVESGGGLVQPGGSLRLSC[M:l-cystine (cross-link)#XL1]AASGFNIKDTYIHWVRQAPGKGLEWVARIYPTNGYTRYADSVKGRFTISADTSKNTAYLQMNSLRAEDTAVYYC[#XL1]SRWGGDGFYAMDYWGQGTLVTVSSASTKGPSVFPLAPSSKSTSGGTAALGC[M:l-cystine (cross-link)#XL2]LVKDYFPEPVTVSWNSGALTSGVHTFPAVLQSSGLYSLSSVVTVPSSSLGTQTYIC[#XL2]NVNHKPSNTKVDKKVEPKSC[M:l-cystine (cross-link)#XL3]DKT//(>Light chain)DIQMTQSPSSLSASVGDRVTITC[M:l-cystine (cross-link)#XL4]RASQDVNTAVAWYQQKPGKAPKLLIYSASFLYSGVPSRFSGSRSGTDFTLTISSLQPEDFATYYC[#XL4]QQHYTTPPTFGQGTKVEIKRTVAAPSVFIFPPSDEQLKSGTASVVC[M:l-cystine (cross-link)#XL5]LLNNFYPREAKVQWKVDNALQSGNSQESVTEQDSKDSTYSLSSTLTLSKADYEKHKVYAC[#XL5]EVTHQGLSSPVTKSFNRGEC[#XL3]+(>Fc)HTCPPCPAPELLGGPSVFLFPPKPKDTLMISRTPEVTCVVVDVSHEDPEVKFNWYVDGVEVHNAKTKPREEQYNSTYRVVSVLTVLHQDWLNGKEYKCKVSNKALPAPIEKTISKAKGQPREPQVYTLPPSREEMTKNQVSLTCLVKGFYPSDIAVEWESNGQPENNYKTTPPVLDSDGSFFLYSKLTVDKSRWQQGNVFSCSVMHEALHNHYTQKSLSLSPGK",
         ]
         for seq in positive:
             with self.subTest(seq=seq):
@@ -800,7 +806,168 @@ class PSIModModificationResolverTest(unittest.TestCase):
         self.assertRaises(ModificationMassNotFoundError, lambda: state.resolve())
 
 
+class InterChainCrossLinkTest(unittest.TestCase):
+    """Section 9.2.2: chains joined by ``//`` are one covalently bonded molecule."""
+
+    SPEC_CASES = [
+        "SEK[XLMOD:02001#XL1]UENCE//EMEVTK[#XL1]SESPEK",
+        "EVTSEKC[Xlink:Disulfide#XL1]LEK//MSC[#XL1]EFDR",
+        "ETFGD[MOD:00093#BRANCH]//R[#BRANCH]ATER",
+        INSULIN,
+    ]
+
+    def test_parses_and_round_trips(self):
+        for seq in self.SPEC_CASES:
+            with self.subTest(seq=seq):
+                ion = ProForma.parse(seq)
+                # The return type does not change: a peptidoform that spans
+                # chains is still a ProForma, with the rest in `chains`.
+                self.assertIsInstance(ion, ProForma)
+                self.assertEqual(len(ion.chains), 2)
+                self.assertTrue(ion.is_multichain)
+                self.assertEqual(str(ion), seq)
+
+    def test_needs_no_opting_in(self):
+        # `//` is only reachable once a peptidoform is complete, so it is never
+        # ambiguous and the caller does not have to know in advance.
+        self.assertEqual(len(ProForma.parse("PEPK//TIDEK").chains), 2)
+
+    def test_a_single_chain_is_unchanged(self):
+        # The whole point of folding the ion tier into ProForma: nothing about
+        # an ordinary peptidoform differs.
+        pf = ProForma.parse("EM[Oxidation]EVEES[Phospho]PEK")
+        self.assertFalse(pf.is_multichain)
+        self.assertEqual(pf.chains, [pf])
+
+    def test_operations_with_no_multichain_meaning_refuse(self):
+        ion = ProForma.parse("PEPK[XLMOD:02001#XL1]//TIDEK[#XL1]")
+        for call in (lambda: ion.fragments("b", 1),
+                     lambda: ion.composition(),
+                     lambda: ion.mz(charge=2),
+                     lambda: list(ion.proteoforms())):
+            with self.subTest(call=call):
+                with self.assertRaises(ValueError) as caught:
+                    call()
+                self.assertIn(".chains", str(caught.exception))
+
+    def test_a_slash_inside_a_tag_or_name_is_not_a_separator(self):
+        for seq in ("PEP[INFO:http://example.com/a]TIDE",
+                    "(>chain//name)PEPTIDE",
+                    "(>>ion//name)PEPTIDE"):
+            with self.subTest(seq=seq):
+                parsed = ProForma.parse(seq)
+                self.assertFalse(parsed.is_multichain)
+                self.assertEqual(str(parsed), seq)
+
+    def test_mass_counts_the_linker_once(self):
+        ion = ProForma.parse("SEK[XLMOD:02001#XL1]UENCE//EMEVTK[#XL1]SESPEK")
+        self.assertAlmostEqual(ion.mass, sum(chain.mass for chain in ion.chains), 6)
+        # The linker is written once; the other site is a bare [#XL1], which
+        # carries no mass. DSS is 138.06808.
+        unlinked = ProForma.parse("SEKUENCE").mass + ProForma.parse("EMEVTKSESPEK").mass
+        self.assertAlmostEqual(ion.mass - unlinked, 138.06808, 5)
+
+    def test_declaring_the_linker_on_each_chain_is_the_same_molecule(self):
+        # Section 9.2.2 gives both spellings. Repeating the declaration lets a
+        # chain be read on its own without hunting for what #XL1 refers to, so
+        # it is a readability affordance rather than an error, and the two must
+        # come to the same mass.
+        both = ProForma.parse(
+            "SEK[XLMOD:02001#XL1]UENCE//EMEVTK[XLMOD:02001#XL1]SESPEK")
+        once = ProForma.parse(
+            "SEK[XLMOD:02001#XL1]UENCE//EMEVTK[#XL1]SESPEK")
+        self.assertAlmostEqual(both.mass, once.mass, 6)
+
+    def test_a_cross_linker_is_never_counted_twice(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            mass = ProForma.parse(
+                "SEK[XLMOD:02001#XL1]UENCE//EMEVTK[XLMOD:02001#XL1]SESPEK").mass
+        unlinked = ProForma.parse("SEKUENCE").mass + ProForma.parse("EMEVTKSESPEK").mass
+        self.assertAlmostEqual(mass - unlinked, 138.06808, 5)
+        # A legitimate spelling should not be complained about.
+        self.assertFalse([w for w in caught if "ross-link" in str(w.message)])
+
+    def test_charge_belongs_to_the_ion(self):
+        ion = ProForma.parse("SEK[XLMOD:02001#XL1]UENCE//EMEVTK[#XL1]SESPEK/2")
+        self.assertEqual(ion.charge_state.charge, 2)
+
+    def test_names_at_every_level(self):
+        # The three naming levels land on the three tiers they describe: the
+        # set and ion names hoist onto the ion, the peptidoform names stay with
+        # the chain each one introduces.
+        seq = "(>>>Trastuzumab)(>>Fab)(>Heavy)PEPK[XLMOD:02001#XL1]//(>Light)TIDEK[#XL1]"
+        ion = ProForma.parse(seq)
+        # Names are recorded by level, as they always have been; the ion and
+        # set names sit on the first chain, which is where the string writes them.
+        self.assertEqual(ion.names.get(3), "Trastuzumab")
+        self.assertEqual(ion.names.get(2), "Fab")
+        self.assertEqual([chain.names.get(1) for chain in ion.chains], ["Heavy", "Light"])
+        # Hoisted, not copied: a chain must not carry the ion or set name, or
+        # it would serialise it once per chain.
+        for chain in ion.chains[1:]:
+            self.assertNotIn(2, chain.names)
+            self.assertNotIn(3, chain.names)
+        # Highest level first, as the specification requires.
+        self.assertEqual(str(ion), seq)
+
+    def test_chimeric_set_of_cross_linked_ions(self):
+        result = ProForma.parse("A[X:DSS#XL1]//B[#XL1]+C[X:DSS#XL1]//D[#XL1]",
+                                chimeric=True)
+        # Still Chimeric[ProForma], as before -- the chains live inside each one.
+        self.assertIsInstance(result, Chimeric)
+        self.assertEqual(len(result), 2)
+        for ion in result:
+            self.assertIsInstance(ion, ProForma)
+            self.assertEqual(len(ion.chains), 2)
+
+    def test_a_self_link_declared_twice_warns_but_still_counts_once(self):
+        # Within one peptide a second declaration is redundant rather than
+        # useful, so section 9.2.1 asks for a bare [#XL1]. Either way the
+        # linker is one molecule and counts once.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            twice = ProForma.parse("EMEVTK[XLMOD:02001#XL1]SESPEK[XLMOD:02001#XL1]").mass
+        once = ProForma.parse("EMEVTK[XLMOD:02001#XL1]SESPEK[#XL1]").mass
+        self.assertAlmostEqual(twice, once, 6)
+        self.assertTrue(any("more than once" in str(w.message) for w in caught))
+
+    def test_chimeric_without_the_flag_says_what_to_do(self):
+        # `+` is the one separator that still needs opting into. It is worth
+        # pinning that the refusal is a clear one, since a caller who has not
+        # met `chimeric=` has no other way to discover it. Checked from both
+        # parser states that can meet a top-level `+`.
+        for seq in ("EMEVEESPEK+ELVISLIVER",          # from the sequence
+                    "EMEVEESPEK/2+ELVISLIVER/3",      # from a charge state
+                    "PEP[+16]TIDE+AA"):
+            with self.subTest(seq=seq):
+                with self.assertRaises(ProFormaError) as caught:
+                    ProForma.parse(seq)
+                message = str(caught.exception)
+                self.assertIn("chimeric=True", message)
+                # and it still parses when asked
+                self.assertEqual(len(ProForma.parse(seq, chimeric=True)), 2)
+
+    def test_a_plus_inside_a_tag_is_not_a_separator(self):
+        # The counterpart to the `//` containment check: a `+` in a mass
+        # modification or an adduct must not look like a chimeric separator.
+        # These normalise on write -- [+16.000] becomes [+16] -- so the claim
+        # is that they parse as one peptidoform, not that they round-trip.
+        for seq in ("PEP[+16.000]TIDE", "EMEVEESPEK/2[+2Na+,+H+]"):
+            with self.subTest(seq=seq):
+                parsed = ProForma.parse(seq)
+                self.assertIsInstance(parsed, ProForma)
+                self.assertFalse(parsed.is_multichain)
+
+    def test_xlmod_counts_as_a_modification(self):
+        # TagTypeEnum.xlmod was missing from TagBase.is_modification, so a
+        # cross-linker was invisible to find_modification.
+        tag = ProForma.parse("EMEVTK[XLMOD:02001#XL1]SESPEK[#XL1]")[5][1][0]
+        self.assertTrue(tag.is_modification())
+
+
 class ModificationTest(unittest.TestCase):
+
     def test_mass_modification_hashable(self):
         mod = MassModification(57.08)
 


### PR DESCRIPTION
Hi there — another PR for inter-chain crosslinks, to round out the last unchecked box in the ProForma implementation. A peptidoform written with `//` gives you a `ProForma` whose new `chains` property holds more than one entry. There's no new type for a cross-linked peptide, and `parse()` and `ProForma.parse()` return exactly what they did before, with no new parameters. (I used an LLM to assist with the code and the description below.) Thanks for considering it!

---

The last unchecked box on the ProForma compliance list reads "cross-linked peptides (using the XL-MOD CV/ontology)", which undersells what is already here: XL-MOD resolves, the X prefix works, and cross-links within one peptide compute the right mass. What was missing is the // notation of section 9.2.2, joining two or more chains into one covalently bonded molecule, refused outright by both parsers.

ProForma is a three-level hierarchy -- peptidoform ion set (+), peptidoform ion (//), peptidoform -- and this modeled the outer and inner levels with Chimeric and ProForma, with nothing between. A string using // yields a ProForma whose `chains` holds more than one entry. What parse() and ProForma.parse() return is unchanged: ProForma, or Chimeric[ProForma]. 

`chains` is the accessor. Quantities belonging to the whole molecule span it -- mass, charge state, and str(), which rejoins with // and writes the (>>name) and (>>>name) prefixes highest-first as the specification requires. Operations with no meaningful multi-chain answer refuse rather than silently answering for the first chain: fragments() and proteoforms() raise, naming `.chains`, as does find_tags_by_id() when positions are requested. composition() and mz() span the chains, since the arithmetic is the same as mass.

A cross-link is one molecule however many sites it bridges, so its mass is counted once however many sites declare it. Where the linker is written once and the other sites carry a bare [#XL1] that falls out of the arithmetic, since a bare reference has no mass. Two cases needed handling:

  - Across chains, repeating the declaration is useful: it lets a chain be read on its own without hunting the others for what #XL1 refers to, and section 9.2.2 writes its examples both ways. Both denote one molecule, so they now agree rather than differing by a linker mass. This reads the blanket requirement in 9.2 that a cross-linker be "mentioned once only" as being about self-links in 9.2.1.

  - Within one peptide a repeat is redundant, which is what 9.2.1 is about. ProForma.mass discounts it too and warns, so the two agree. The scan is guarded on a #XL group being present, leaving the common path as it was.

ProFormaParseResult stops being an alias for a bare tuple and becomes the type that carries an ion's chains. For a single chain it still unpacks and compares as the (positions, properties) pair it was, so `positions, properties = parse(s)` is unaffected.

Eleven previously commented-out cases now run, covering inter-chain cross-links, #BRANCH, disulfides, chimeric sets of cross-linked ions, and the full Trastuzumab example with its five inter-chain disulfides and all three naming levels.

Two fixes fell out of the work. TagTypeEnum.xlmod was missing from TagBase.is_modification, so find_modification could not see a cross-linker at all. And the commented-out insulin case was a truncated copy of the specification's example: everything before the A chain's last residue had been lost, taking the #XL1 and #XL2 definitions with it and leaving two references to groups that were never defined. Restored from section 9.2.3.
