### PR TITLE
fix(proforma): reject a second N-terminal modification group

### DIFF
--- a/pyteomics/proforma.py
+++ b/pyteomics/proforma.py
@@ -2967,6 +2967,21 @@ class Parser:
             self.unlocalized_modifications.extend(self.current_tag())
             self.state = BEFORE
         elif c == "-":
+            if self.n_term:
+                # The grammar allows a single N-terminal group:
+                #     peptidoform = ... [modNTerm], sequence, [modCTerm]
+                #     modNTerm = modOrLabel, [modOrLabel], "-"
+                # Assigning here instead of rejecting silently discarded the earlier
+                # group, so e.g. "[UNIMOD:5]-[UNIMOD:385]-PEPTIDE" parsed as if only
+                # UNIMOD:385 were present, losing 43 Da without any warning.
+                raise ProFormaError(
+                    f"Error In State {self.state}, found a second N-terminal modification group "
+                    f"at index {self.index}; ProForma allows only one N-terminal group. Multiple "
+                    f"N-terminal modifications are written in a single group, e.g. "
+                    f"'[UNIMOD:5][UNIMOD:385]-PEPTIDE'",
+                    self.index,
+                    self.state,
+                )
             self.n_term = self.current_tag()
             self.state = BEFORE
         elif c == "^":

--- a/tests/test_proforma.py
+++ b/tests/test_proforma.py
@@ -62,6 +62,34 @@ class ProFormaTest(unittest.TestCase):
         self.assertRaises(ProFormaError, lambda: parse(
             "PRQT(EQ(CFQR)[Carbamidomethyl]MS)[+19.0523]ISK"))
 
+    def test_error_on_second_n_terminal_group(self):
+        # The grammar permits one N-terminal group:
+        #   peptidoform = ... [modNTerm], sequence, [modCTerm]
+        #   modNTerm = modOrLabel, [modOrLabel], "-"
+        # A second group used to overwrite the first, so this parsed as if only the
+        # last modification were present instead of raising.
+        self.assertRaises(ProFormaError, lambda: parse("[UNIMOD:5]-[UNIMOD:385]-PEPTIDE"))
+        self.assertRaises(ProFormaError, lambda: parse("[Acetyl]-[Phospho]-PEPTIDE"))
+        # Also rejected when the discarded group would have been the only difference.
+        self.assertRaises(ProFormaError, lambda: parse("[Formula:H-2C1O1]-[Acetyl]-PEPTIDE"))
+
+    def test_multiple_n_terminal_modifications_in_one_group(self):
+        # The supported spelling for two N-terminal modifications is a single group.
+        # Assert the mass, not just that it parses: the bug this guards against silently
+        # dropped a modification, which a parse-only check would not have caught.
+        # Carbamylation (UNIMOD:5, +43.005814) with ammonia loss (UNIMOD:385, -17.026549)
+        # is +25.979265 Da, equal to [Formula:H-2C1O1] and [+25.979265].
+        base = ProForma.parse("PEPTIDE").mass
+        expected = 25.979265
+        for seq in ("[UNIMOD:5][UNIMOD:385]-PEPTIDE",
+                    "[Formula:H-2C1O1]-PEPTIDE",
+                    "[+25.979265]-PEPTIDE"):
+            obj = ProForma.parse(seq)
+            self.assertAlmostEqual(obj.mass - base, expected, 5, msg=seq)
+        # The two-modification group keeps both tags rather than collapsing them.
+        obj = ProForma.parse("[UNIMOD:5][UNIMOD:385]-PEPTIDE")
+        self.assertEqual(len(obj.properties['n_term']), 2)
+
     def test_localization_scores(self):
         seq = "EM[Oxidation]EVT[#g1(0.01)]S[#g1(0.09)]ES[Phospho#g1(0.90)]PEK"
         obj = ProForma.parse(seq)


### PR DESCRIPTION
## Summary

`ProForma.parse` accepts a peptidoform with two N-terminal modification groups and
silently keeps only the last one. `[UNIMOD:5]-[UNIMOD:385]-PEPTIDE` parses without
error as if only `UNIMOD:385` were present, discarding carbamylation (+43.005814 Da):

```python
>>> from pyteomics import proforma
>>> base = proforma.ProForma.parse("PEPTIDE").mass
>>> proforma.ProForma.parse("[UNIMOD:5][UNIMOD:385]-PEPTIDE").mass - base
25.979265        # correct: carbamylation (+43.005814) with ammonia loss (-17.026549)
>>> proforma.ProForma.parse("[UNIMOD:5]-[UNIMOD:385]-PEPTIDE").mass - base
-17.026549       # accepted, and 43.005814 Da has vanished
```

The grammar (`grammar/proforma.ebnf` in [HUPO-PSI/ProForma]) permits a single
N-terminal group:

```ebnf
peptidoform = [namePeptidoform], {globalModUnknownPos}, {modLabile}, [modNTerm], sequence, [modCTerm];
modNTerm    = modOrLabel, [modOrLabel], "-";
```

`[modNTerm]` is optional but not repeatable, and after the `-` the grammar requires
`sequence`, which must begin with an `aminoAcid` (a `LETTER`) — so a second `[` there is
not valid input.

## Cause

`handle_post_tag_before` **assigned** `self.n_term` when consuming the `-` that
terminates an N-terminal group:

```python
elif c == "-":
    self.n_term = self.current_tag()
    self.state = BEFORE
```

`self.n_term` is initialised to `[]` and is never checked, so the parser returns to the
`BEFORE` state where another `[` legitimately starts a new tag-before-sequence. When that
group's `-` arrives, the assignment overwrites the earlier group. The modification is not
merged, flagged, or warned about — it is simply gone.

## Fix

Raise `ProFormaError` when a second N-terminal group is encountered, and name the
supported spelling in the message so the correct form is obvious:

```python
elif c == "-":
    if self.n_term:
        raise ProFormaError(
            f"Error In State {self.state}, found a second N-terminal modification group "
            f"at index {self.index}; ProForma allows only one N-terminal group. Multiple "
            f"N-terminal modifications are written in a single group, e.g. "
            f"'[UNIMOD:5][UNIMOD:385]-PEPTIDE'",
            self.index,
            self.state,
        )
    self.n_term = self.current_tag()
    self.state = BEFORE
```


Silent modification loss is worse than a parse error, because the result stays plausible.
The peptide still parses, still has a mass, and is wrong by exactly one modification,
there is nothing downstream to notice.

## Tests

Two tests in `tests/test_proforma.py`:

- `test_error_on_second_n_terminal_group` — asserts `ProFormaError` for
  `[UNIMOD:5]-[UNIMOD:385]-PEPTIDE`, `[Acetyl]-[Phospho]-PEPTIDE`, and
  `[Formula:H-2C1O1]-[Acetyl]-PEPTIDE`.
- `test_multiple_n_terminal_modifications_in_one_group` — asserts the **mass** of the
  three equivalent valid spellings (`[UNIMOD:5][UNIMOD:385]-`, `[Formula:H-2C1O1]-`,
  `[+25.979265]-`), all +25.979265 Da, and that the two-tag group retains both tags.
  Asserting mass rather than only parse success is deliberate: a parse-only check would
  not have caught the original bug, since the buggy input parsed fine.

**Verified the tests catch the regression** — reverting the parser change fails
`test_error_on_second_n_terminal_group` with `AssertionError: ProFormaError not raised`;
restoring it passes.


| input | |
|---|---|
| `[UNIMOD:5][UNIMOD:385]-PEPTIDE` | two mods, one group |
| `[Formula:H-2C1O1]-PEPTIDE` | negative formula cardinality (`SIGNEDINT`) |
| `[+25.979265]-PEPTIDE` | mass delta |
| `PEPTIDE-[UNIMOD:1]` | C-terminal |
| `[UNIMOD:1]-PEPTIDE-[UNIMOD:2]` | both termini |
| `[UNIMOD:1]?PEPTIDE`, `[UNIMOD:1]^2?PEPTIDE` | unlocalized, with count |
| `<[Carbamidomethyl]@C>PEPTIDCE` | global fixed rule |
| `{Glycan:Hex}[Acetyl]-PEPTIDE` | labile plus N-terminal |

## Left out on purpose

The parser also accepts **three or more** tags in a single N-terminal group, e.g.
`[UNIMOD:5][UNIMOD:385][UNIMOD:1]-PEPTIDE`, which `modNTerm = modOrLabel, [modOrLabel], "-"`
caps at two. I have not changed that, for two reasons: it is lossless (the mass sums all
three, +67.989830 Da, so no information disappears), and the second `modOrLabel` slot may
be intended to carry a label rather than a second modification, making a hard cap a
stricter reading than I want to impose without maintainer input.

[HUPO-PSI/ProForma]: https://github.com/HUPO-PSI/ProForma
