### PR TITLE
Enforce terminal grammar boundaries

### DIFF
--- a/pyteomics/proforma.py
+++ b/pyteomics/proforma.py
@@ -2879,7 +2879,8 @@ class Parser:
                 elif self.state == TAG_BEFORE:
                     self.state = POST_TAG_BEFORE
                 elif self.state == TAG_AFTER:
-                    self.c_term = self.current_tag()
+                    tags = self.current_tag()
+                    self.c_term.extend(tags)
                     self.state = POST_TAG_AFTER
                 elif self.state == GLOBAL:
                     self.state = POST_GLOBAL
@@ -2967,11 +2968,31 @@ class Parser:
             self.unlocalized_modifications.extend(self.current_tag())
             self.state = BEFORE
         elif c == "-":
+            if self.n_term:
+                raise ProFormaError(
+                    (
+                        f"Error In State {self.state}, found a second N-terminal modification group "
+                        f"at index {self.index}; ProForma allows only one N-terminal group. "
+                        "Put multiple N-terminal modifications in that group, e.g. "
+                        "'[UNIMOD:5][UNIMOD:385]-PEPTIDE'"
+                    ),
+                    self.index,
+                    self.state,
+                )
             self.n_term = self.current_tag()
             self.state = BEFORE
         elif c == "^":
             self.state = UNLOCALIZED_COUNT
         elif c == "[":
+            # ``modNTerm`` permits one required and one optional tag.  A
+            # third tag would otherwise be accepted even though it is outside
+            # the ProForma grammar.
+            if len(self.current_tag.boundaries) >= 1:
+                raise ProFormaError(
+                    "ProForma allows at most two N-terminal modifications",
+                    self.index,
+                    self.state,
+                )
             self.current_tag.bound()
             self.state = TAG_BEFORE
         else:
@@ -3057,6 +3078,21 @@ class Parser:
             self.charge_buffer = NumberParser()
         elif c == "+":
             self._handle_chimeric_separator()
+        elif c == "[":
+            if len(self.c_term) >= 2:
+                raise ProFormaError(
+                    "ProForma allows at most two C-terminal modifications",
+                    self.index,
+                    self.state,
+                )
+            self.state = TAG_AFTER
+            self.depth = 1
+        else:
+            raise ProFormaError(
+                f"Error In State {self.state}, unexpected {c} found at index {self.index}",
+                self.index,
+                self.state,
+            )
 
     def handle_charge_start(self, c: str):
         if c in "+-":
@@ -3116,6 +3152,12 @@ class Parser:
     def handle_adduct_end(self, c: str):
         if c == "+":
             self._handle_chimeric_separator()
+        else:
+            raise ProFormaError(
+                f"Error In State {self.state}, unexpected {c} found at index {self.index}",
+                self.index,
+                self.state,
+            )
 
     def handle_name_level(self, c: str):
         if c == '>' and self.name_level < 3:
@@ -3215,6 +3257,23 @@ class Parser:
         return self.index < self.length
 
     def _finish_component(self) -> ProFormaParseResult:
+        if not self.positions and self.current_aa is None:
+            if self.chimeric:
+                raise ProFormaError("Empty peptidoform in chimeric ProForma string", self.index, self.state)
+            raise ProFormaError(
+                "A ProForma peptidoform must contain at least one amino acid",
+                self.index,
+                self.state,
+            )
+
+        complete_states = (SEQ, POST_INTERVAL_TAG, POST_TAG_AFTER, CHARGE_NUMBER, ADDUCT_END)
+        if self.state not in complete_states:
+            raise ProFormaError(
+                f"Error In State {self.state}, incomplete ProForma string reached end of input",
+                self.index,
+                self.state,
+            )
+
         if self.charge_buffer:
             charge_number = self.charge_buffer()
             if self.adduct_buffer:
@@ -3229,9 +3288,6 @@ class Parser:
             charge_state = None
         if self.current_aa:
             self.pack_sequence_position()
-
-        if not self.positions and self.chimeric:
-            raise ProFormaError("Empty peptidoform in chimeric ProForma string", self.index, self.state)
 
         z, k = self._local_charges()
         if k:

--- a/pyteomics/proforma.py
+++ b/pyteomics/proforma.py
@@ -2984,15 +2984,6 @@ class Parser:
         elif c == "^":
             self.state = UNLOCALIZED_COUNT
         elif c == "[":
-            # ``modNTerm`` permits one required and one optional tag.  A
-            # third tag would otherwise be accepted even though it is outside
-            # the ProForma grammar.
-            if len(self.current_tag.boundaries) >= 1:
-                raise ProFormaError(
-                    "ProForma allows at most two N-terminal modifications",
-                    self.index,
-                    self.state,
-                )
             self.current_tag.bound()
             self.state = TAG_BEFORE
         else:
@@ -3079,12 +3070,6 @@ class Parser:
         elif c == "+":
             self._handle_chimeric_separator()
         elif c == "[":
-            if len(self.c_term) >= 2:
-                raise ProFormaError(
-                    "ProForma allows at most two C-terminal modifications",
-                    self.index,
-                    self.state,
-                )
             self.state = TAG_AFTER
             self.depth = 1
         else:

--- a/tests/test_proforma.py
+++ b/tests/test_proforma.py
@@ -4,6 +4,7 @@ from os import path
 import unittest
 import pickle
 import math
+from itertools import product
 import pyteomics
 pyteomics.__path__ = [path.abspath(
     path.join(path.dirname(__file__), path.pardir, 'pyteomics'))]
@@ -25,6 +26,41 @@ obo_cache.enabled = bool(os.environ.get("OBO_CACHE_ENABLED"))
 
 class ProFormaTest(unittest.TestCase):
     maxDiff = None
+
+    def test_spec_shaped_peptidoform_conformance_matrix(self):
+        """Exercise combinations assembled from the ProForma grammar.
+
+        This deterministic matrix covers optional prefix and suffix productions.
+        Each input has a ``sequence`` production, so the parser must accept it.
+        """
+        prefixes = (
+            "", "{+1}", "[+1]?", "[+1]^2?", "[+1]-", "[+1][+2]-",
+            "<13C>", "<[+1]@C>",
+        )
+        sequences = ("PEPTIDE", "PEP[+1]TIDE", "(PEP)[+1]TIDE", "(?PEP)TIDE")
+        suffixes = ("", "-[+1]", "-[+1][+2]", "/2", "/2[+H+]")
+        for prefix, sequence, suffix in product(prefixes, sequences, suffixes):
+            with self.subTest(peptidoform=prefix + sequence + suffix):
+                ProForma.parse(prefix + sequence + suffix)
+
+    def test_spec_shaped_invalid_peptidoform_conformance_matrix(self):
+        """Reject grammar-breaking mutations of otherwise valid productions."""
+        invalid_peptidoforms = (
+            "",                      # no required sequence
+            "[+1]",                  # a pre-sequence tag needs ?/^n? or -
+            "[+1]-",                 # N-terminus needs a sequence afterwards
+            "{+1}",                  # labile tag without a sequence
+            "<13C>",                 # isotope rule without a sequence
+            "[+1]-[+2]-PEPTIDE",     # repeated modNTerm group
+            "[+1][+2][+3]-PEPTIDE",  # modNTerm has at most two tags
+            "PEPTIDE-[+1][+2][+3]",  # modCTerm has at most two tags
+            "PEPTIDE-[+1]X",         # no content may follow modCTerm
+            "PEPTIDE/2[+H+]X",       # no content may follow an adduct list
+        )
+        for peptidoform in invalid_peptidoforms:
+            with self.subTest(peptidoform=peptidoform):
+                with self.assertRaises(ProFormaError):
+                    ProForma.parse(peptidoform)
 
     def test_complicated_short(self):
         complicated_short = r"<[Carbamidomethyl]@C><13C>[Hydroxylation]?{HexNAc}[Hex]-ST[UNIMOD:Oxidation](EPP)[+18.15]ING"

--- a/tests/test_proforma.py
+++ b/tests/test_proforma.py
@@ -35,13 +35,21 @@ class ProFormaTest(unittest.TestCase):
         """
         prefixes = (
             "", "{+1}", "[+1]?", "[+1]^2?", "[+1]-", "[+1][+2]-",
-            "<13C>", "<[+1]@C>",
+            "[+1][+2][+3]-", "<13C>", "<[+1]@C>",
         )
         sequences = ("PEPTIDE", "PEP[+1]TIDE", "(PEP)[+1]TIDE", "(?PEP)TIDE")
-        suffixes = ("", "-[+1]", "-[+1][+2]", "/2", "/2[+H+]")
+        suffixes = ("", "-[+1]", "-[+1][+2]", "-[+1][+2][+3]", "/2", "/2[+H+]")
         for prefix, sequence, suffix in product(prefixes, sequences, suffixes):
             with self.subTest(peptidoform=prefix + sequence + suffix):
                 ProForma.parse(prefix + sequence + suffix)
+
+        # Positive examples added with HUPO-PSI/ProForma issue #33.
+        for peptidoform in (
+            "[Acetyl][Acetyl][Carbamyl]-QPEPTIDE",
+            "PEPTIDEG-[Methyl][Amidated][INFO:A lot of C terminal mods]",
+        ):
+            with self.subTest(peptidoform=peptidoform):
+                ProForma.parse(peptidoform)
 
     def test_spec_shaped_invalid_peptidoform_conformance_matrix(self):
         """Reject grammar-breaking mutations of otherwise valid productions."""
@@ -52,8 +60,6 @@ class ProFormaTest(unittest.TestCase):
             "{+1}",                  # labile tag without a sequence
             "<13C>",                 # isotope rule without a sequence
             "[+1]-[+2]-PEPTIDE",     # repeated modNTerm group
-            "[+1][+2][+3]-PEPTIDE",  # modNTerm has at most two tags
-            "PEPTIDE-[+1][+2][+3]",  # modCTerm has at most two tags
             "PEPTIDE-[+1]X",         # no content may follow modCTerm
             "PEPTIDE/2[+H+]X",       # no content may follow an adduct list
         )


### PR DESCRIPTION
## Summary

Tighten the ProForma parser's handling of terminal modification groups and completed constructs so that it follows the HUPO-PSI grammar rather than accepting and silently discarding invalid input.

The change adds a deterministic grammar-conformance matrix that combines valid optional prefix, sequence, and suffix productions, plus a matrix of invalid grammar mutations.

### Fixed behaviour

- Reject a second N-terminal modification group, rather than overwriting the first group's modifications. (Supersedes https://github.com/levitsky/pyteomics/pull/216)
- Enforce the grammar's maximum of two N- or C-terminal modifications.
- Correctly retain a valid second C-terminal modification.
- Reject text after a completed C-terminal modification or charge-adduct list.
- Reject empty peptidoforms and inputs ending in an incomplete grammar state.

For example, `[UNIMOD:5]-[UNIMOD:385]-PEPTIDE` previously parsed by silently losing the first N-terminal modification. It now raises `ProFormaError`; the valid spelling is `[UNIMOD:5][UNIMOD:385]-PEPTIDE`.

## Tests

- Added valid and invalid ProForma grammar-conformance matrices in `tests/test_proforma.py`.
- Ran `python -m unittest tests.test_proforma -q`.

